### PR TITLE
feat(group): implement group module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +174,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -161,13 +211,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -181,6 +239,12 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -198,6 +262,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +296,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -228,14 +326,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -243,6 +360,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -272,6 +395,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -305,6 +441,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +504,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +571,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "yconn"
 version = "0.1.0"
 dependencies = [
@@ -372,5 +667,12 @@ dependencies = [
  "dirs",
  "serde",
  "serde_yaml",
+ "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ thiserror = "2.0.18"
 
 [profile.release]
 strip = true
+
+[dev-dependencies]
+tempfile = "3.26.0"

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -1,14 +1,350 @@
-// src/group/mod.rs
-// Active group resolution, session.yml read/write.
-//
-// Reads and writes ~/.config/yconn/session.yml. Resolves the active group
-// name (defaulting to "connections" when the file is absent). Scans all
-// layer directories to discover which groups have config files, used by
-// `yconn group list`.
+//! Active group resolution and session.yml read/write.
+//!
+//! Reads and writes `~/.config/yconn/session.yml`. Resolves the active group
+//! name (defaulting to `"connections"` when the file is absent or the key is
+//! unset). Scans layer directories to discover which groups have config files,
+//! used by `yconn group list`.
 
-use anyhow::Result;
+// Public API is consumed by CLI command modules not yet implemented.
+#![allow(dead_code)]
 
-#[allow(dead_code)]
-pub fn run() -> Result<()> {
-    todo!()
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+// ─── Public constants ─────────────────────────────────────────────────────────
+
+/// The group name used when no `active_group` is set in `session.yml`.
+pub const DEFAULT_GROUP: &str = "connections";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/// The resolved active group and whether it came from `session.yml`.
+pub struct ActiveGroup {
+    /// The group name (never empty; defaults to [`DEFAULT_GROUP`]).
+    pub name: String,
+    /// `true` = read from `session.yml`; `false` = using the built-in default.
+    pub from_file: bool,
+}
+
+/// A group discovered by scanning layer config directories.
+pub struct GroupEntry {
+    pub name: String,
+    /// Which layers have a config file for this group (e.g. `["project", "user"]`).
+    pub layers: Vec<String>,
+}
+
+// ─── serde type for session.yml ──────────────────────────────────────────────
+
+/// Wire type for `~/.config/yconn/session.yml`.
+///
+/// Unknown keys are silently ignored by serde's default behaviour, which
+/// preserves forward compatibility with future versions.
+#[derive(Deserialize, Serialize, Default)]
+struct SessionFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    active_group: Option<String>,
+}
+
+// ─── Path helpers ─────────────────────────────────────────────────────────────
+
+fn session_path() -> Result<PathBuf> {
+    let base = dirs::config_dir().context("cannot determine user config directory")?;
+    Ok(base.join("yconn").join("session.yml"))
+}
+
+// ─── Private I/O helpers (also used directly by tests) ───────────────────────
+
+fn read_session_at(path: &Path) -> Result<ActiveGroup> {
+    if !path.exists() {
+        return Ok(ActiveGroup {
+            name: DEFAULT_GROUP.into(),
+            from_file: false,
+        });
+    }
+
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    let file: SessionFile = serde_yaml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    match file.active_group.filter(|s| !s.is_empty()) {
+        Some(name) => Ok(ActiveGroup {
+            name,
+            from_file: true,
+        }),
+        None => Ok(ActiveGroup {
+            name: DEFAULT_GROUP.into(),
+            from_file: false,
+        }),
+    }
+}
+
+fn write_session_at(path: &Path, group: Option<&str>) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+
+    let file = SessionFile {
+        active_group: group.map(str::to_owned),
+    };
+    let content = serde_yaml::to_string(&file).context("failed to serialise session file")?;
+
+    std::fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
+
+    Ok(())
+}
+
+fn discover_in_dirs(dirs: &[(&Path, &str)]) -> Result<Vec<GroupEntry>> {
+    // BTreeMap keeps groups sorted by name for stable output.
+    let mut map: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for (dir, layer_label) in dirs {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => continue, // directory absent or unreadable — skip silently
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+                continue;
+            }
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            // Skip the session state file — it is not a group config.
+            if stem == "session" {
+                continue;
+            }
+            map.entry(stem).or_default().push(layer_label.to_string());
+        }
+    }
+
+    Ok(map
+        .into_iter()
+        .map(|(name, layers)| GroupEntry { name, layers })
+        .collect())
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/// Return the active group, reading `session.yml` via the standard path.
+///
+/// Returns `DEFAULT_GROUP` when the file is absent or `active_group` is unset.
+pub fn active_group() -> Result<ActiveGroup> {
+    read_session_at(&session_path()?)
+}
+
+/// Persist `name` as the active group in `session.yml`.
+pub fn set_active_group(name: &str) -> Result<()> {
+    write_session_at(&session_path()?, Some(name))
+}
+
+/// Remove `active_group` from `session.yml`, reverting to the default.
+pub fn clear_active_group() -> Result<()> {
+    write_session_at(&session_path()?, None)
+}
+
+/// Scan `dirs` — each `(directory, layer_label)` pair — and return all groups
+/// found across them.
+///
+/// The caller is responsible for building the directory list (including the
+/// project-layer path obtained from the upward walk). Directories that do not
+/// exist are silently skipped.
+///
+/// Results are sorted by group name.
+pub fn discover_groups(dirs: &[(&Path, &str)]) -> Result<Vec<GroupEntry>> {
+    discover_in_dirs(dirs)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // ── session read ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_read_session_file_absent() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(!ag.from_file);
+    }
+
+    #[test]
+    fn test_read_session_active_group_set() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        fs::write(&path, "active_group: work\n").unwrap();
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, "work");
+        assert!(ag.from_file);
+    }
+
+    #[test]
+    fn test_read_session_active_group_empty_string() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        fs::write(&path, "active_group: \"\"\n").unwrap();
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(!ag.from_file);
+    }
+
+    #[test]
+    fn test_read_session_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        fs::write(&path, "").unwrap();
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(!ag.from_file);
+    }
+
+    #[test]
+    fn test_read_session_unknown_keys_ignored() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        fs::write(&path, "active_group: staging\nsome_future_key: 42\n").unwrap();
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, "staging");
+        assert!(ag.from_file);
+    }
+
+    // ── session write ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_write_session_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        assert!(!path.exists());
+        write_session_at(&path, Some("work")).unwrap();
+        assert!(path.exists());
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, "work");
+    }
+
+    #[test]
+    fn test_write_session_creates_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("dirs").join("session.yml");
+        write_session_at(&path, Some("work")).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_write_session_clear_removes_key() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        write_session_at(&path, Some("work")).unwrap();
+        write_session_at(&path, None).unwrap();
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(!ag.from_file);
+    }
+
+    #[test]
+    fn test_write_session_overwrite_existing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        write_session_at(&path, Some("work")).unwrap();
+        write_session_at(&path, Some("private")).unwrap();
+        let ag = read_session_at(&path).unwrap();
+        assert_eq!(ag.name, "private");
+    }
+
+    // ── group discovery ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_discover_no_dirs() {
+        let groups = discover_in_dirs(&[]).unwrap();
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_discover_missing_dirs_silently_skipped() {
+        let dir = TempDir::new().unwrap();
+        let absent = dir.path().join("does-not-exist");
+        let groups = discover_in_dirs(&[(&absent, "project")]).unwrap();
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_discover_single_layer() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("connections.yaml"), "").unwrap();
+        fs::write(dir.path().join("work.yaml"), "").unwrap();
+        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
+        assert_eq!(groups.len(), 2);
+        let connections = groups.iter().find(|g| g.name == "connections").unwrap();
+        assert_eq!(connections.layers, vec!["user"]);
+        let work = groups.iter().find(|g| g.name == "work").unwrap();
+        assert_eq!(work.layers, vec!["user"]);
+    }
+
+    #[test]
+    fn test_discover_multiple_layers_same_group() {
+        let project = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        let system = TempDir::new().unwrap();
+
+        fs::write(project.path().join("work.yaml"), "").unwrap();
+        fs::write(user.path().join("work.yaml"), "").unwrap();
+        fs::write(system.path().join("connections.yaml"), "").unwrap();
+
+        let groups = discover_in_dirs(&[
+            (project.path(), "project"),
+            (user.path(), "user"),
+            (system.path(), "system"),
+        ])
+        .unwrap();
+
+        let work = groups.iter().find(|g| g.name == "work").unwrap();
+        assert_eq!(work.layers, vec!["project", "user"]);
+
+        let connections = groups.iter().find(|g| g.name == "connections").unwrap();
+        assert_eq!(connections.layers, vec!["system"]);
+    }
+
+    #[test]
+    fn test_discover_skips_session_file() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("session.yml"), "").unwrap();
+        fs::write(dir.path().join("connections.yaml"), "").unwrap();
+        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].name, "connections");
+    }
+
+    #[test]
+    fn test_discover_skips_non_yaml_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("connections.yaml"), "").unwrap();
+        fs::write(dir.path().join("README.md"), "").unwrap();
+        fs::write(dir.path().join("notes.txt"), "").unwrap();
+        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
+        assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn test_discover_results_sorted_by_name() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("work.yaml"), "").unwrap();
+        fs::write(dir.path().join("connections.yaml"), "").unwrap();
+        fs::write(dir.path().join("private.yaml"), "").unwrap();
+        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
+        let names: Vec<&str> = groups.iter().map(|g| g.name.as_str()).collect();
+        assert_eq!(names, vec!["connections", "private", "work"]);
+    }
 }


### PR DESCRIPTION
Implements task: Implement group module

- session.yml read/write with serde (unknown keys ignored for forward compat)
- active_group() with from_file flag for display
- set_active_group() / clear_active_group()
- discover_groups() scans caller-provided (dir, label) pairs
- 14 unit tests covering all CLAUDE.md scenarios
- Bumps default Rust toolchain to stable 1.93.1 (required by tempfile dev dep)