### PR TITLE
chore: align project with current plugin workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,3 +3,8 @@
 @../CLAUDE.md
 
 @~/.claude/plugins/cache/yanct-claude-plugin/CLAUDE.md
+
+## Version Control Rules
+
+- Never push directly to main or master — always use a feature branch and PR
+- All PRs must be merged with a squash commit — never merge commit or rebase merge

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,19 @@
 {
+  "permissions": {
+    "allow": [
+      "Write",
+      "Bash(make *)",
+      "Bash(git *)",
+      "Bash(mkdir *)",
+      "Bash(touch *)",
+      "Bash(cp *)",
+      "Bash(cargo init *)",
+      "Bash(cargo add *)",
+      "Bash(rustup *)",
+      "Bash(chmod *)",
+      "Bash(sudo apt-get *)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 
-.PHONY: build lint test clean release package docs
+.PHONY: build lint fmt fmt-check test clean release package docs
 
 BINARY := $(shell grep '^name' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
@@ -9,8 +9,14 @@ TARGET := x86_64-unknown-linux-musl
 build:
 	cargo build --release --target $(TARGET)
 
-lint:
+fmt:
+	cargo fmt
+
+fmt-check:
 	cargo fmt --check
+
+lint:
+	$(MAKE) fmt-check
 	cargo clippy -- -D warnings
 
 test:


### PR DESCRIPTION
## Summary

- Added version control rules to `.claude/CLAUDE.md` (no direct pushes to main, squash-only merges)
- Added universal and rust-specific `permissions.allow` entries to `.claude/settings.json`
- Added `fmt:` and `fmt-check:` targets to `Makefile`; updated `lint:` to delegate to `$(MAKE) fmt-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)