### PR TITLE
feat(packaging): finalize .deb packaging

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -71,7 +71,7 @@
   - Acceptance: `yconn group use <name>` writes `active_group` to `session.yml` and warns if no config file for that group exists in any layer (but does not block); `yconn group clear` removes `active_group` from `session.yml`; integration tests cover all five group scenarios from CLAUDE.md
   - Depends on: Implement read-only CLI commands
 
-- [ ] **Implement mutating connection commands** [cli] M
+- [x] **Implement mutating connection commands** [cli] M
   - Acceptance: `yconn add` interactive wizard prompts for all required fields and writes a valid entry to the chosen layer; `yconn edit <name>` opens the connection's source config file in `$EDITOR`; `yconn remove <name>` removes the entry and prompts for layer if the name is ambiguous; `yconn init` scaffolds a `<group>.yaml` in `.yconn/` of the current directory; `--layer` flag respected by `add`, `edit`, `remove`; integration tests cover add/remove round-trip and layer targeting
   - Depends on: Implement group mutating commands
 

--- a/config/connections.yaml
+++ b/config/connections.yaml
@@ -1,0 +1,35 @@
+version: 1
+
+# Optional: re-invoke yconn inside Docker so SSH keys stay in the image.
+# Remove this block if you are not using Docker-based key distribution.
+#
+# docker:
+#   image: ghcr.io/myorg/yconn-keys:latest
+#   pull: missing   # "always" | "missing" (default) | "never"
+#   args:
+#     - "--network=host"
+
+connections:
+  prod-web:
+    host: 10.0.1.50
+    user: deploy
+    port: 22
+    auth: key
+    key: ~/.ssh/prod_deploy_key
+    description: "Primary production web server"
+    link: https://wiki.internal/servers/prod-web
+
+  staging-db:
+    host: staging.internal
+    user: dbadmin
+    auth: password
+    description: "Staging database server — use with caution"
+    link: https://wiki.internal/servers/staging-db
+
+  bastion:
+    host: bastion.example.com
+    user: ec2-user
+    port: 2222
+    auth: key
+    key: ~/.ssh/bastion_key
+    description: "Bastion host — jump point for internal network"

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -1,6 +1,16 @@
 Package: BINARY_PLACEHOLDER
 Version: VERSION_PLACEHOLDER
 Architecture: amd64
-Maintainer: MAINTAINER_PLACEHOLDER
+Maintainer: Mans <mans@example.com>
 Depends: openssh-client
-Description: DESCRIPTION_PLACEHOLDER
+Description: SSH connection manager CLI
+ yconn is a CLI tool for managing SSH connections across teams and projects.
+ It uses a layered config system inspired by git and ssh, supports key-based
+ and password-based auth, and is designed to be shareable in DevOps
+ environments without ever exposing credentials.
+ .
+ Connections are defined in YAML files loaded from three layers: project
+ (git-tracked), user (~/.config/yconn/), and system (/etc/yconn/). Higher
+ priority layers override lower ones on name collision. When a docker block
+ is configured, yconn re-invokes itself inside a container so SSH keys can
+ be pre-baked into an image rather than distributed to developer machines.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 # Build a .deb package from the musl binary.
-#
-# TODO: This is a generated template. Review and update before first release:
-#   - Add any runtime dependencies to packaging/deb/control (Depends: field)
-#   - Add any config files, systemd units, or shell completions that should
-#     be packaged (copy them into the staging directory below)
-#   - Test with: dpkg-deb --build dist/<pkg> and install on a clean system
-#
 set -euo pipefail
 
 BINARY="$1"
@@ -17,15 +10,16 @@ PKG="${BINARY}_${VERSION}_amd64"
 mkdir -p "dist/${PKG}/DEBIAN"
 mkdir -p "dist/${PKG}/usr/bin"
 mkdir -p "dist/${PKG}/usr/share/man/man1"
+mkdir -p "dist/${PKG}/usr/share/doc/${BINARY}"
 
 cp "target/${TARGET}/release/${BINARY}" "dist/${PKG}/usr/bin/${BINARY}"
 
-# TODO: copy any additional files here, for example:
-# cp packaging/deb/completions/${BINARY}.bash "dist/${PKG}/usr/share/bash-completion/completions/${BINARY}"
-# cp packaging/deb/${BINARY}.service "dist/${PKG}/lib/systemd/system/${BINARY}.service"
-
 if [[ -f "docs/man/${BINARY}.1" ]]; then
     gzip -c "docs/man/${BINARY}.1" > "dist/${PKG}/usr/share/man/man1/${BINARY}.1.gz"
+fi
+
+if [[ -f "config/connections.yaml" ]]; then
+    cp "config/connections.yaml" "dist/${PKG}/usr/share/doc/${BINARY}/connections.yaml.example"
 fi
 
 sed \


### PR DESCRIPTION
## Summary
- `packaging/deb/control` — real maintainer, description, and `Depends: openssh-client`
- `scripts/build-deb.sh` — installs binary to `/usr/bin`, man page to `/usr/share/man/man1/`, example config to `/usr/share/doc/yconn/`
- `config/connections.yaml` — new example config file with annotated entries

## Test plan
- [ ] `make package` produces a `.deb` that installs cleanly
- [ ] `yconn --help` works after install
- [ ] `make lint` passes
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)