### PR TITLE
feat(packaging): add crates.io publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,7 @@ jobs:
             docs/man/${{ env.BINARY }}.1
             dist/*.deb
             dist/PKGBUILD
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "yconn"
 version = "0.1.0"
 edition = "2021"
+description = "SSH connection manager for teams and DevOps environments"
+license = "MIT"
+repository = "https://github.com/yanctab/yconn"
+homepage = "https://github.com/yanctab/yconn"
+readme = "README.md"
+keywords = ["ssh", "connections", "devops", "cli", "manager"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.102"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 yanctab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 
-.PHONY: build lint fmt fmt-check test clean release package docs
+.PHONY: build lint fmt fmt-check test clean release package docs publish
 
 BINARY := $(shell grep '^name' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
@@ -42,3 +42,6 @@ build-deb:
 
 build-aur:
 	@scripts/build-aur.sh $(BINARY) $(VERSION)
+
+publish: lint test
+	cargo publish

--- a/TASKS.md
+++ b/TASKS.md
@@ -82,3 +82,7 @@
 - [x] **Finalize AUR PKGBUILD** [packaging] M
   - Acceptance: `packaging/aur/PKGBUILD.template` has correct `pkgdesc`, `depends=(openssh)`, installs binary and man page; `scripts/build-aur.sh` produces a valid `dist/PKGBUILD`; template verified with `makepkg --printsrcinfo` producing a valid `.SRCINFO`
   - Depends on: Finalize .deb packaging
+
+- [x] **Publish to crates.io** [packaging] S
+  - Acceptance: `Cargo.toml` has required crates.io fields (`description`, `license`) plus discoverability fields (`repository`, `homepage`, `readme`, `keywords`, `categories`); `LICENSE` file present (MIT, 2026, yanctab); `make publish` target runs lint + test then `cargo publish`; `cargo publish --dry-run` exits 0; release CI (`release.yml`) runs `cargo publish` after GitHub Release step using `CARGO_REGISTRY_TOKEN` secret
+  - Depends on: Finalize AUR PKGBUILD


### PR DESCRIPTION
## Summary

- Add required crates.io metadata to `Cargo.toml` (`description`, `license`, `repository`, `homepage`, `readme`, `keywords`, `categories`)
- Create `LICENSE` file (MIT, 2026, yanctab)
- Add `make publish` target (gated on `lint` + `test`)
- Wire `cargo publish` into `release.yml` after the GitHub Release step, using `CARGO_REGISTRY_TOKEN` secret

## Pre-publish requirement (one-time, manual)

Before the first tagged release, add a crates.io API token as a GitHub Actions secret named `CARGO_REGISTRY_TOKEN`:
1. crates.io → Account Settings → API Tokens → New Token (scopes: `publish-new` + `publish-update`)
2. Repo Settings → Secrets and variables → Actions → New repository secret

## Test plan

- [ ] `cargo publish --dry-run` exits 0
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)