### PR TITLE
ci(release): use CRATES_IO_TOKEN secret for crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
             dist/PKGBUILD
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish


### PR DESCRIPTION
## Summary
- Updates the release workflow to use the `CRATES_IO_TOKEN` repository secret instead of the previously expected `CARGO_REGISTRY_TOKEN`

## Test plan
- [ ] Verify the `CRATES_IO_TOKEN` secret exists in the repo settings
- [ ] Push a version tag and confirm the publish step succeeds in CI