### PR TITLE
feat(packaging): replace AUR PKGBUILD with Arch .pkg.tar.zst release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl
-      - run: sudo apt-get install -y musl-tools pandoc
+      - run: sudo apt-get install -y musl-tools pandoc zstd
       - run: make build
       - run: make docs
       - run: make package
@@ -25,9 +25,8 @@ jobs:
         with:
           files: |
             target/x86_64-unknown-linux-musl/release/${{ env.BINARY }}
-            docs/man/${{ env.BINARY }}.1
             dist/*.deb
-            dist/PKGBUILD
+            dist/*.pkg.tar.zst
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ release:
 	git tag v$(VERSION)
 	git push origin v$(VERSION)
 
-## package - build .deb and AUR packages from the release binary
+## package - build .deb and Arch .pkg.tar.zst from the release binary
 package:
 	$(MAKE) build
 	$(MAKE) build-deb
-	$(MAKE) build-aur
+	$(MAKE) build-pkg
 
 ## docs - generate man page from markdown source
 docs:
@@ -53,8 +53,8 @@ docs:
 build-deb:
 	@scripts/build-deb.sh $(BINARY) $(VERSION)
 
-build-aur:
-	@scripts/build-aur.sh $(BINARY) $(VERSION)
+build-pkg:
+	@scripts/build-pkg.sh $(BINARY) $(VERSION)
 
 ## publish - publish the crate to crates.io
 publish: lint test

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build an Arch Linux .pkg.tar.zst package from the musl binary.
+set -euo pipefail
+
+BINARY="$1"
+VERSION="$2"
+TARGET="x86_64-unknown-linux-musl"
+PKGREL=1
+DESCRIPTION="SSH connection manager CLI with layered YAML config and Docker bootstrap support"
+URL="https://github.com/yanctab/yconn"
+
+STAGING="dist/.pkg-staging"
+rm -rf "${STAGING}"
+mkdir -p "${STAGING}/usr/bin"
+mkdir -p "${STAGING}/usr/share/man/man1"
+
+cp "target/${TARGET}/release/${BINARY}" "${STAGING}/usr/bin/${BINARY}"
+
+if [[ -f "docs/man/${BINARY}.1" ]]; then
+    gzip -c "docs/man/${BINARY}.1" > "${STAGING}/usr/share/man/man1/${BINARY}.1.gz"
+fi
+
+ISIZE=$(find "${STAGING}" -type f -exec wc -c {} + | tail -1 | awk '{print $1}')
+
+cat > "${STAGING}/.PKGINFO" << EOF
+pkgname = ${BINARY}
+pkgver = ${VERSION}-${PKGREL}
+pkgdesc = ${DESCRIPTION}
+url = ${URL}
+builddate = $(date +%s)
+packager = Unknown Packager
+size = ${ISIZE}
+arch = x86_64
+license = MIT
+depend = openssh
+EOF
+
+OUTFILE="dist/${BINARY}-${VERSION}-${PKGREL}-x86_64.pkg.tar.zst"
+tar -C "${STAGING}" -cf - . | zstd -q -o "${OUTFILE}"
+
+rm -rf "${STAGING}"
+echo "Built ${OUTFILE}"


### PR DESCRIPTION
## Summary

- Adds `scripts/build-pkg.sh` which builds a proper Arch Linux `.pkg.tar.zst` containing the binary and gzipped man page
- Replaces `make build-aur` with `make build-pkg` in the `package` target
- Updates `release.yml` to install `zstd`, upload `dist/*.pkg.tar.zst`, and drop the standalone `PKGBUILD` and `yconn.1` as release assets
- Release now contains three assets: raw binary, `.deb`, and `.pkg.tar.zst`

## Install on Arch Linux

```
sudo pacman -U yconn-1.0.0-1-x86_64.pkg.tar.zst
```

## Test plan

- [ ] Confirm CI passes on this branch
- [ ] Verify `make package` produces `dist/yconn-*-x86_64.pkg.tar.zst`
- [ ] Verify release assets after merging and tagging