### PR TITLE
feat(packaging): automate version bump in make release target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "yconn"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,22 @@ test:
 clean:
 	cargo clean
 
-## release - tag the current version in Cargo.toml and push to trigger the release pipeline
+## release - bump minor version, commit, tag, and push to trigger the release pipeline
 release:
-	git tag v$(VERSION)
-	git push origin v$(VERSION)
+	@git fetch --tags
+	@LATEST=$$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1); \
+	if [ -z "$$LATEST" ]; then echo "error: no semver tag found"; exit 1; fi; \
+	MAJOR=$$(echo "$$LATEST" | sed 's/^v//' | cut -d. -f1); \
+	MINOR=$$(echo "$$LATEST" | sed 's/^v//' | cut -d. -f2); \
+	NEW_MINOR=$$((MINOR + 1)); \
+	NEW_VERSION="$$MAJOR.$$NEW_MINOR.0"; \
+	echo "Bumping $$LATEST -> v$$NEW_VERSION"; \
+	sed -i "s/^version = \".*\"/version = \"$$NEW_VERSION\"/" Cargo.toml; \
+	cargo update -p yconn; \
+	git add Cargo.toml Cargo.lock; \
+	git commit -m "yconn v$$NEW_VERSION"; \
+	git tag "v$$NEW_VERSION"; \
+	git push origin HEAD "v$$NEW_VERSION"
 
 ## package - build .deb and AUR packages from the release binary
 package:

--- a/TASKS.md
+++ b/TASKS.md
@@ -86,3 +86,11 @@
 - [x] **Publish to crates.io** [packaging] S
   - Acceptance: `Cargo.toml` has required crates.io fields (`description`, `license`) plus discoverability fields (`repository`, `homepage`, `readme`, `keywords`, `categories`); `LICENSE` file present (MIT, 2026, yanctab); `make publish` target runs lint + test then `cargo publish`; `cargo publish --dry-run` exits 0; release CI (`release.yml`) runs `cargo publish` after GitHub Release step using `CARGO_REGISTRY_TOKEN` secret
   - Depends on: Finalize AUR PKGBUILD
+
+- [x] **Automate version bump in make release target** [packaging] S
+  - Acceptance: `make release` runs `git fetch --tags`, finds the latest semver tag, increments its minor component (resetting patch to 0), updates `version = "..."` in `Cargo.toml`, runs `cargo update -p yconn` to sync `Cargo.lock`, commits with message `yconn v<new-version>`, creates `v<new-version>` tag, and pushes commit + tag to origin; the `## release` help comment in the Makefile is updated to describe the new behaviour; `make help` output reflects this; no manual version edits are needed before running `make release`
+  - Depends on: Publish to crates.io
+  - Modify: Makefile
+  - Create: none
+  - Reuse: Makefile:VERSION (grep+sed extraction pattern), Makefile:release (target to be replaced)
+  - Risks: `sed -i` syntax differs between GNU and BSD/macOS — use `sed -i ''` guard or restrict to Linux; minor bump must reset patch to 0; `git fetch --tags` requires network access — the target should fail fast if fetch fails


### PR DESCRIPTION
## Summary

- Replaces the manual `make release` target with a fully automated version-bump script
- Fetches all tags, finds the latest semver tag, increments minor (resets patch to 0), updates `Cargo.toml`, syncs `Cargo.lock`, commits, tags, and pushes — all in one step
- Updates the `## release` help comment so `make help` reflects the new behaviour
- Also includes the new task entry in `TASKS.md` and the pre-existing `Cargo.lock` version drift fix

## Test plan

- [ ] `make help` shows updated description for the `release` target
- [ ] `make -n release` (dry run) prints the expected sequence of commands
- [ ] All 176 tests pass (`make test`)
- [ ] Lint is clean (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)