### PR TITLE
docs: add configuration reference and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ SSH connection manager CLI — manage named SSH connections across teams and pro
 
 Connections live in YAML files at three layers (project, user, system). Higher layers override lower ones on name collision. When a Docker image is configured, yconn re-invokes itself inside the container so SSH keys can be pre-baked into an image rather than distributed to individual machines.
 
+## Documentation
+
+- [Configuration reference](docs/configuration.md) — layer system, all config fields, Docker block, session file, credential policy
+- [Examples](docs/examples.md) — copy-paste-ready scenarios: project-layer only, project + user layers, Docker-enabled setup, multi-group setup
+
 ## Installation
 
 ### Arch Linux (AUR)
@@ -24,39 +29,7 @@ cargo build --release --target x86_64-unknown-linux-musl
 
 The compiled binary is placed at `target/x86_64-unknown-linux-musl/release/yconn`.
 
-## Usage
-
-```
-yconn [OPTIONS] COMMAND
-```
-
-### Commands
-
-| Command | Description |
-|---|---|
-| `yconn list` | List all connections across all layers |
-| `yconn connect <name>` | Connect to a named host |
-| `yconn show <name>` | Show resolved config for a connection (no secrets printed) |
-| `yconn add` | Interactive wizard to add a connection to a chosen layer |
-| `yconn edit <name>` | Open the connection's source config file in `$EDITOR` |
-| `yconn remove <name>` | Remove a connection (prompts for layer if ambiguous) |
-| `yconn init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
-| `yconn config` | Show active config files, their paths, and Docker status |
-| `yconn group list` | Show all groups found across all layers |
-| `yconn group use <name>` | Set the active group |
-| `yconn group clear` | Revert to the default group (`connections`) |
-| `yconn group current` | Print the active group name and resolved config file paths |
-
-### Global flags
-
-| Flag | Description |
-|---|---|
-| `--layer system\|user\|project` | Target a specific layer for `add`, `edit`, `remove` |
-| `--all` | Include shadowed entries in `yconn list` |
-| `--verbose` | Print config loading, merge decisions, and full Docker invocation |
-| `--no-color` | Disable colored output |
-
-### Quick start
+## Quick start
 
 ```bash
 # Scaffold a project config in the current directory
@@ -73,47 +46,26 @@ yconn connect prod-web
 
 # Switch to a named group
 yconn group use work
-yconn config
 ```
 
-## Config file format
+## Commands
 
-```yaml
-version: 1
+| Command | Description |
+|---|---|
+| `yconn list` | List all connections across all layers |
+| `yconn connect <name>` | Connect to a named host |
+| `yconn show <name>` | Show resolved config for a connection (no secrets printed) |
+| `yconn add` | Interactive wizard to add a connection to a chosen layer |
+| `yconn edit <name>` | Open the connection's source config file in `$EDITOR` |
+| `yconn remove <name>` | Remove a connection (prompts for layer if ambiguous) |
+| `yconn init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
+| `yconn config` | Show active config files, their paths, and Docker status |
+| `yconn group list` | Show all groups found across all layers |
+| `yconn group use <name>` | Set the active group |
+| `yconn group clear` | Revert to the default group (`connections`) |
+| `yconn group current` | Print the active group name and resolved config file paths |
 
-# Optional: re-invoke inside Docker so SSH keys stay in the image
-docker:
-  image: ghcr.io/myorg/yconn-keys:latest
-  pull: missing   # "always" | "missing" (default) | "never"
-  args:
-    - "--network=host"
-
-connections:
-  prod-web:
-    host: 10.0.1.50
-    user: deploy
-    port: 22
-    auth: key
-    key: ~/.ssh/prod_deploy_key
-    description: "Primary production web server"
-    link: https://wiki.internal/servers/prod-web
-
-  staging-db:
-    host: staging.internal
-    user: dbadmin
-    auth: password
-    description: "Staging database server"
-```
-
-Config files are loaded from (highest to lowest priority):
-
-| Layer | Path (default group) | Notes |
-|---|---|---|
-| project | `.yconn/connections.yaml` | Lives in git — no credentials |
-| user | `~/.config/yconn/connections.yaml` | Private to local user |
-| system | `/etc/yconn/connections.yaml` | Org-wide, sysadmin-managed |
-
-The active group (set with `yconn group use <name>`) changes which filename is loaded from each layer. Switching to group `work` loads `work.yaml` from each layer instead.
+Global flags: `--layer system|user|project`, `--all`, `--verbose`, `--no-color`
 
 ## Development
 
@@ -125,4 +77,4 @@ make docs     # generate docs/man/yconn.1 via pandoc
 make release  # tag and trigger release pipeline
 ```
 
-See `man yconn` for full documentation after `make docs`.
+See `man yconn` for the full command reference after `make docs`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -94,3 +94,11 @@
   - Create: none
   - Reuse: Makefile:VERSION (grep+sed extraction pattern), Makefile:release (target to be replaced)
   - Risks: `sed -i` syntax differs between GNU and BSD/macOS — use `sed -i ''` guard or restrict to Linux; minor bump must reset patch to 0; `git fetch --tags` requires network access — the target should fail fast if fetch fails
+
+- [x] **Create docs directory with configuration reference and examples** [docs] M
+  - Acceptance: `docs/configuration.md` covers the full config file format (all fields, credential policy, Docker block, layer priority) extracted from README.md; `docs/examples.md` contains at least four complete, copy-paste-ready scenarios (project-layer only, project + user layers, Docker-enabled setup, multi-group setup) each with realistic YAML snippets and the exact `yconn` commands to use them; README.md is trimmed to a concise overview + installation + quick start that links to the new docs pages; all relative links between README.md and docs/ resolve correctly on GitHub
+  - Depends on: Automate version bump in make release target
+  - Modify: README.md
+  - Create: docs/configuration.md, docs/examples.md
+  - Reuse: config/connections.yaml (example YAML to draw from), docs/man/yconn.1.md (existing reference content to avoid duplicating)
+  - Risks: README must remain a useful standalone entry point on GitHub — do not over-strip it; avoid duplicating man page content verbatim; relative links (e.g. `[Configuration](docs/configuration.md)`) must use paths relative to the repo root to work on GitHub

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,249 @@
+# Configuration Reference
+
+This document covers the full configuration system for yconn: the layer hierarchy, file format,
+connection fields, Docker block, session file, and credential policy.
+
+---
+
+## Layer system
+
+yconn loads configuration from up to three layers and merges them. Higher-priority layers win on
+name collision — a connection defined in a higher-priority layer completely replaces any
+connection with the same name in a lower-priority layer.
+
+| Priority | Layer | Default path | Notes |
+|---|---|---|---|
+| 1 (highest) | project | `.yconn/connections.yaml` | Lives in git — no credentials |
+| 2 | user | `~/.config/yconn/connections.yaml` | Private to the local user |
+| 3 (lowest) | system | `/etc/yconn/connections.yaml` | Org-wide defaults, sysadmin-managed |
+
+A layer that has no file for the active group is silently skipped — not all layers need to define
+entries for every group.
+
+### Project config discovery
+
+The project layer is found by walking upward from the current working directory (like git),
+checking each parent directory for a `.yconn/<group>.yaml`. The walk stops at `$HOME` or the
+filesystem root. This means running from deep inside a project tree will find the config at the
+repo root.
+
+### Groups and filenames
+
+The active group determines which filename is loaded from each layer. The default group is
+`connections`, which maps to `connections.yaml`. Switching to a group named `work` causes
+`work.yaml` to be loaded from each layer instead.
+
+| Active group | File loaded from each layer |
+|---|---|
+| `connections` (default) | `connections.yaml` |
+| `work` | `work.yaml` |
+| `client-acme` | `client-acme.yaml` |
+
+See `yconn group --help` or [docs/examples.md](examples.md#multi-group-setup) for group commands.
+
+---
+
+## Config file format
+
+Each config file is a YAML document with a `version` key, an optional `docker` block, and a
+`connections` map.
+
+```yaml
+version: 1
+
+docker:
+  image: ghcr.io/myorg/yconn-keys:latest
+  pull: missing   # "always" | "missing" (default) | "never"
+  args:
+    - "--network=host"
+    - "--env=MY_VAR=value"
+    - "--volume=/opt/certs:/opt/certs:ro"
+
+connections:
+  prod-web:
+    host: 10.0.1.50
+    user: deploy
+    port: 22
+    auth: key
+    key: ~/.ssh/prod_deploy_key
+    description: "Primary production web server"
+    link: https://wiki.internal/servers/prod-web
+
+  staging-db:
+    host: staging.internal
+    user: dbadmin
+    auth: password
+    description: "Staging database server — use with caution"
+    link: https://wiki.internal/servers/staging-db
+
+  bastion:
+    host: bastion.example.com
+    user: ec2-user
+    port: 2222
+    auth: key
+    key: ~/.ssh/bastion_key
+    description: "Bastion host — jump point for internal network"
+```
+
+---
+
+## Connection fields
+
+| Field | Required | Description |
+|---|---|---|
+| `host` | yes | Hostname or IP address |
+| `user` | yes | SSH login user |
+| `port` | no | SSH port — defaults to `22` |
+| `auth` | yes | `key` or `password` |
+| `key` | if `auth: key` | Path to private key file. When using Docker, the path is resolved inside the container. |
+| `description` | yes | Human-readable description of the connection |
+| `link` | no | URL for further documentation (wiki, runbook, etc.) |
+
+Each connection entry requires an explicit `host`. There is no pattern or glob matching — every
+host that should be reachable must have its own named entry.
+
+---
+
+## Docker block
+
+The `docker` block, when present, causes yconn to re-invoke itself inside a container before
+connecting. This allows SSH keys to be pre-baked into an image rather than distributed to
+developer machines.
+
+```yaml
+docker:
+  image: ghcr.io/myorg/yconn-keys:latest
+  pull: missing
+  args:
+    - "--network=host"
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `image` | yes (to enable Docker mode) | Docker image to re-invoke yconn inside. If absent, Docker mode is disabled. |
+| `pull` | no | When to pull the image: `always`, `missing` (default), or `never` |
+| `args` | no | List of additional arguments appended to `docker run` before the image name |
+
+`args` are inserted after yconn's own injected arguments and before the image name. This allows
+extending the container with extra networks, volumes, environment variables, or any other
+`docker run` flag without changing yconn itself. Arguments are passed through verbatim — yconn
+does not validate them.
+
+### Trusted layers for docker block
+
+The `docker` block is **only** trusted from the **project** (`.yconn/`) and **system**
+(`/etc/yconn/`) layers. If a `docker` block is found in the user layer (`~/.config/yconn/`),
+it is ignored with a warning. This prevents a user config from silently redirecting execution
+to an arbitrary Docker image.
+
+---
+
+## Docker bootstrap behaviour
+
+When `docker.image` is configured and yconn is not already running inside a container, it
+constructs and executes the following `docker run` command:
+
+```
+docker run
+  --name yconn-connection-<pid>
+  -i
+  -t
+  --rm
+  -e CONN_IN_DOCKER=1
+  -v <yconn-binary>:<yconn-binary>:ro
+  -v /etc/yconn:/etc/yconn:ro
+  -v ${HOME}/.config/yconn:${HOME}/.config/yconn
+  -w $(pwd)
+  [user args from docker.args]
+  <image>
+  yconn <subcommand> <args>
+```
+
+The original subcommand and arguments are passed through verbatim.
+
+### What gets mounted
+
+| Host path | Container path | Mode | Purpose |
+|---|---|---|---|
+| `yconn` binary | same absolute path | `ro` | Same binary runs inside the container |
+| `/etc/yconn/` | `/etc/yconn/` | `ro` | System layer config |
+| `~/.config/yconn/` | `~/.config/yconn/` | `rw` | User layer config and `session.yml` |
+| `$(pwd)` | `$(pwd)` | `ro` | Working dir — enables upward walk to find project config |
+
+The project-level `.yconn/` config is not explicitly mounted. It is reached via the `-w $(pwd)`
+working directory mount combined with the upward directory walk that yconn performs at startup.
+
+All mounts except `~/.config/yconn` are read-only. The user config directory is read-write so
+that `session.yml` can be updated from inside the container (for example, `yconn group use`
+works correctly whether invoked inside or outside Docker).
+
+### Container detection
+
+yconn considers itself inside a container when **any** of the following are true:
+
+- The file `/.dockerenv` exists
+- The environment variable `CONN_IN_DOCKER` is set to `1`
+
+yconn sets `CONN_IN_DOCKER=1` in the environment of every container it starts. This prevents
+infinite re-invocation even in images that do not create `/.dockerenv`.
+
+### Verbose output
+
+Pass `--verbose` to print the full `docker run` command before it is executed:
+
+```
+[yconn] Docker image configured: ghcr.io/myorg/yconn-keys:latest
+[yconn] Not running inside container — bootstrapping into Docker
+[yconn] Running: docker run \
+         --name yconn-connection-84732 \
+         -i -t --rm \
+         -e CONN_IN_DOCKER=1 \
+         -v /usr/local/bin/yconn:/usr/local/bin/yconn:ro \
+         -v /etc/yconn:/etc/yconn:ro \
+         -v /home/user/.config/yconn:/home/user/.config/yconn \
+         -w /home/user/projects/acme \
+         --network=host \
+         ghcr.io/myorg/yconn-keys:latest \
+         yconn connect prod-web
+```
+
+---
+
+## Session file
+
+`~/.config/yconn/session.yml` holds user session state that persists across invocations. It is
+never committed to git and is scoped to the local user only.
+
+```yaml
+active_group: work
+```
+
+| Key | Description |
+|---|---|
+| `active_group` | The active group name. Omit or leave blank to use the default (`connections`). |
+
+The file is designed for forward compatibility — unknown keys are ignored rather than causing
+errors. An empty or absent file is valid and treated as all-defaults.
+
+---
+
+## Credential policy
+
+| Layer | Path | Credential policy |
+|---|---|---|
+| project | `.yconn/` | Must never contain credentials. Host, user, auth type, key name references, and docker config only. Git-tracked configs are scanned on load; a warning is emitted if credential fields are found. |
+| user | `~/.config/yconn/` | May reference local key paths. This is the only layer where credential references belong. |
+| system | `/etc/yconn/` | Must never contain credentials. Org-wide defaults managed by sysadmins. |
+
+Passwords are never stored in any config file and are never passed as CLI arguments or
+environment variables. SSH prompts natively when `auth: password` is configured. Key
+passphrases are delegated entirely to `ssh-agent`.
+
+All security warnings are non-blocking — yconn will still proceed after warning.
+
+---
+
+## See also
+
+- [Examples](examples.md) — copy-paste-ready scenarios
+- `man yconn` — full command reference

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,342 @@
+# Examples
+
+Copy-paste-ready scenarios for common yconn setups.
+
+---
+
+## Project-layer only
+
+**When to use:** Your whole team works with the same set of servers and you want the connection
+list checked into the project repository.
+
+Create a project config file at the root of your repository:
+
+```
+your-project/
+└── .yconn/
+    └── connections.yaml
+```
+
+**`.yconn/connections.yaml`**
+
+```yaml
+version: 1
+
+connections:
+  prod-web:
+    host: 10.0.1.50
+    user: deploy
+    port: 22
+    auth: key
+    key: ~/.ssh/prod_deploy_key
+    description: "Primary production web server"
+    link: https://wiki.internal/servers/prod-web
+
+  staging-db:
+    host: staging.internal
+    user: dbadmin
+    auth: password
+    description: "Staging database server — use with caution"
+    link: https://wiki.internal/servers/staging-db
+
+  bastion:
+    host: bastion.example.com
+    user: ec2-user
+    port: 2222
+    auth: key
+    key: ~/.ssh/bastion_key
+    description: "Bastion host — jump point for internal network"
+```
+
+**Commands:**
+
+```bash
+# Scaffold the .yconn/ directory and connections.yaml in the current directory
+yconn init
+
+# List all connections
+yconn list
+
+# Show full details for a connection
+yconn show prod-web
+
+# Connect
+yconn connect prod-web
+yconn connect bastion
+```
+
+**Notes:**
+
+- The `key` paths (e.g. `~/.ssh/prod_deploy_key`) are resolved on each developer's local
+  machine. Every developer must have the referenced key files in place.
+- Do not put passwords or key passphrases in this file — it lives in git. Key passphrases
+  are handled by `ssh-agent`.
+- Commit `.yconn/connections.yaml` to version control. All team members get the connection
+  list automatically after `git pull`.
+
+---
+
+## Project + user layers
+
+**When to use:** The team shares a project config, but you want to override one connection
+locally — for example to use a different SSH key or a personal jump host.
+
+**`.yconn/connections.yaml`** (committed to git — shared by the whole team)
+
+```yaml
+version: 1
+
+connections:
+  prod-web:
+    host: 10.0.1.50
+    user: deploy
+    auth: key
+    key: ~/.ssh/team_deploy_key
+    description: "Primary production web server"
+
+  staging-db:
+    host: staging.internal
+    user: dbadmin
+    auth: password
+    description: "Staging database server"
+```
+
+**`~/.config/yconn/connections.yaml`** (local to your machine — not in git)
+
+```yaml
+version: 1
+
+connections:
+  # Override the shared prod-web entry with your personal key
+  prod-web:
+    host: 10.0.1.50
+    user: deploy
+    auth: key
+    key: ~/.ssh/my_personal_deploy_key
+    description: "Primary production web server (personal key override)"
+
+  # Add a private entry that only you need
+  dev-vm:
+    host: 192.168.1.5
+    user: root
+    auth: key
+    key: ~/.ssh/id_rsa
+    description: "Local development VM"
+```
+
+**Commands:**
+
+```bash
+# List connections — prod-web shows from user layer (your override wins)
+yconn list
+
+# See where prod-web comes from
+yconn show prod-web
+# Source: user (/home/you/.config/yconn/connections.yaml)
+
+# See all entries including the shadowed team version
+yconn list --all
+# prod-web appears twice: user layer (active) and project layer (shadowed)
+
+# Connect using your overridden key
+yconn connect prod-web
+```
+
+**Notes:**
+
+- The user layer (`~/.config/yconn/`) takes higher priority than the project layer
+  (`.yconn/`). Any connection defined in both layers will use the user-layer values.
+- The project layer entry for `prod-web` is still present — `yconn list --all` shows it
+  with a `[shadowed]` tag.
+- Unique connection names (like `dev-vm`) are simply merged in alongside project entries.
+
+---
+
+## Docker-enabled setup
+
+**When to use:** You want SSH keys to live inside a Docker image rather than on developer
+machines. Developers pull the image and connect without needing the key files locally.
+
+**`.yconn/connections.yaml`** (committed to git)
+
+```yaml
+version: 1
+
+docker:
+  image: ghcr.io/myorg/yconn-keys:latest
+  pull: missing   # pull if not already present locally
+  args:
+    - "--network=host"
+
+connections:
+  prod-web:
+    host: 10.0.1.50
+    user: deploy
+    auth: key
+    key: /keys/prod_deploy_key   # path inside the Docker image
+    description: "Primary production web server"
+
+  staging-db:
+    host: staging.internal
+    user: dbadmin
+    auth: password
+    description: "Staging database server"
+
+  bastion:
+    host: bastion.example.com
+    user: ec2-user
+    port: 2222
+    auth: key
+    key: /keys/bastion_key       # path inside the Docker image
+    description: "Bastion host"
+```
+
+**Commands:**
+
+```bash
+# Connect — yconn detects the docker block, pulls the image if needed,
+# and re-invokes itself inside the container
+yconn connect prod-web
+
+# See the full docker run command before execution
+yconn connect --verbose prod-web
+
+# Check Docker status and which image would be used
+yconn config
+```
+
+**How it works:**
+
+1. yconn starts on the host, loads the config, and finds `docker.image` set.
+2. It checks whether it is already running inside a container (`/.dockerenv` or
+   `CONN_IN_DOCKER=1`). It is not, so it builds a `docker run` command.
+3. The container gets the yconn binary, all config layers, and the current working
+   directory mounted. The original command (`connect prod-web`) is passed through.
+4. Inside the container, yconn sees `CONN_IN_DOCKER=1` and skips the Docker step.
+   It invokes SSH directly using the key at `/keys/prod_deploy_key` inside the image.
+
+**Building the keys image** (example Dockerfile):
+
+```dockerfile
+FROM alpine:3.21
+RUN apk add --no-cache openssh-client
+COPY keys/prod_deploy_key /keys/prod_deploy_key
+COPY keys/bastion_key /keys/bastion_key
+RUN chmod 600 /keys/prod_deploy_key /keys/bastion_key
+```
+
+**Notes:**
+
+- The `docker` block is only trusted from the project (`.yconn/`) and system
+  (`/etc/yconn/`) layers. A `docker` block in `~/.config/yconn/` is ignored with a warning.
+- Key paths in the connection entries (e.g. `/keys/prod_deploy_key`) are resolved
+  inside the container, not on the host.
+- Pass `--network=host` in `docker.args` only when the container needs to reach hosts
+  on the host network directly.
+
+---
+
+## Multi-group setup
+
+**When to use:** You have logically separate sets of connections — for example `work` and
+`private` — and want to switch between them cleanly without mixing entries in one file.
+
+**File layout:**
+
+```
+~/.config/yconn/
+├── work.yaml
+└── private.yaml
+```
+
+**`~/.config/yconn/work.yaml`**
+
+```yaml
+version: 1
+
+connections:
+  work-web:
+    host: 10.10.0.5
+    user: deploy
+    auth: key
+    key: ~/.ssh/work_key
+    description: "Work production web server"
+
+  work-db:
+    host: 10.10.0.10
+    user: dbadmin
+    auth: password
+    description: "Work database server"
+```
+
+**`~/.config/yconn/private.yaml`**
+
+```yaml
+version: 1
+
+connections:
+  home-server:
+    host: 192.168.1.100
+    user: mans
+    auth: key
+    key: ~/.ssh/id_ed25519
+    description: "Home server"
+
+  vps:
+    host: vps.example.com
+    user: root
+    auth: key
+    key: ~/.ssh/vps_key
+    description: "Personal VPS"
+```
+
+**Commands:**
+
+```bash
+# List all available groups across all layers
+yconn group list
+
+# Switch to the work group
+yconn group use work
+
+# List connections — now shows work.yaml entries
+yconn list
+
+# Connect to a work server
+yconn connect work-web
+
+# Switch to the private group
+yconn group use private
+
+# List connections — now shows private.yaml entries
+yconn list
+
+# Connect to the home server
+yconn connect home-server
+
+# Check which group is currently active and which files are loaded
+yconn group current
+
+# Revert to the default group (connections.yaml)
+yconn group clear
+```
+
+**Notes:**
+
+- The active group is stored in `~/.config/yconn/session.yml` and persists across
+  terminal sessions until changed.
+- Each group is independent — switching groups changes which `.yaml` file is loaded
+  from every layer. A group with no file in a given layer simply skips that layer.
+- Groups can also be used at the project layer. For example, a repo with both
+  `.yconn/work.yaml` and a team member's user-level `~/.config/yconn/work.yaml`
+  will merge the two when the `work` group is active, with the project layer winning
+  on any name collision.
+- `yconn group use <name>` warns if no config file for that group exists in any layer,
+  but it still sets the group so you can follow up by creating the file with `yconn init`.
+
+---
+
+## See also
+
+- [Configuration reference](configuration.md) — full field reference and layer system
+- `man yconn` — full command reference


### PR DESCRIPTION
## Summary

- Creates `docs/configuration.md` — full config reference covering the 3-layer system, all YAML fields (connection + Docker block), credential policy per layer, session file schema, and Docker bootstrap behaviour
- Creates `docs/examples.md` — four copy-paste-ready scenarios: project-layer only, project + user layer override, Docker-enabled setup with keys in an image, and multi-group setup
- Trims `README.md` to a concise overview + installation + quick start, removes the verbose inline config section, and adds a Documentation section with relative links to the new pages

## Test plan

- [ ] `docs/configuration.md` renders correctly on GitHub
- [ ] `docs/examples.md` renders correctly on GitHub with all YAML blocks
- [ ] README.md links to `docs/configuration.md` and `docs/examples.md` resolve on GitHub
- [ ] All 176 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)