### PR TITLE
feat(packaging): add make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # Makefile
 
-.PHONY: build lint fmt fmt-check test clean release package docs publish help
+.PHONY: build install lint fmt fmt-check test clean release package docs publish help
 
 BINARY := $(shell grep '^name' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
 TARGET := x86_64-unknown-linux-musl
+PREFIX ?= /usr/local
 
 ## help - show available targets
 help:
@@ -13,6 +14,13 @@ help:
 ## build - compile a static musl release binary
 build:
 	cargo build --release --target $(TARGET)
+
+## install - install binary (and man page if built) to PREFIX=/usr/local — use sudo for system paths
+install: build
+	install -Dm755 target/$(TARGET)/release/$(BINARY) $(PREFIX)/bin/$(BINARY)
+	@if [ -f docs/man/$(BINARY).1 ]; then \
+		install -Dm644 docs/man/$(BINARY).1 $(PREFIX)/share/man/man1/$(BINARY).1; \
+	fi
 
 ## fmt - auto-format code with cargo fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ sudo dpkg -i yconn_0.1.0_amd64.deb
 ```
 
 ### From source
-```
-cargo build --release --target x86_64-unknown-linux-musl
+```bash
+git clone https://github.com/yanctab/yconn.git
+cd yconn
+make build
+sudo make install          # installs to /usr/local/bin/yconn
+# or: make install PREFIX=~/.local   # installs to ~/.local/bin/yconn (no sudo needed)
 ```
 
-The compiled binary is placed at `target/x86_64-unknown-linux-musl/release/yconn`.
+The man page is also installed if you have run `make docs` first.
 
 ## Quick start
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -102,3 +102,19 @@
   - Create: docs/configuration.md, docs/examples.md
   - Reuse: config/connections.yaml (example YAML to draw from), docs/man/yconn.1.md (existing reference content to avoid duplicating)
   - Risks: README must remain a useful standalone entry point on GitHub — do not over-strip it; avoid duplicating man page content verbatim; relative links (e.g. `[Configuration](docs/configuration.md)`) must use paths relative to the repo root to work on GitHub
+
+- [x] **Add make install target** [packaging] S
+  - Acceptance: `make install` depends on `build`, installs the binary to `$(PREFIX)/bin/$(BINARY)` (default `PREFIX=/usr/local`) using `install -Dm755`, and installs the man page to `$(PREFIX)/share/man/man1/$(BINARY).1` if `docs/man/$(BINARY).1` exists; the `## install` help comment notes that `sudo` is needed for system-level `PREFIX` paths; `make install` exits 0 and `yconn --help` works afterwards; README.md from-source section is updated to show `make install` as the installation step
+  - Depends on: Create docs directory with configuration reference and examples
+  - Modify: Makefile, README.md
+  - Create: none
+  - Reuse: Makefile:BINARY (name extraction), Makefile:build (dependency), packaging/aur/PKGBUILD.template (install -Dm755 pattern)
+  - Risks: man page install must be conditional on `docs/man/$(BINARY).1` existing (make docs may not have been run); help comment should mention `sudo make install` for /usr/local; do not hardcode /usr/local — use PREFIX variable
+
+- [ ] **Update README installation instructions for Arch and Debian pre-built packages** [docs] S
+  - Acceptance: Arch Linux section replaces `yay -S yconn` with both a one-step `sudo pacman -U <github-release-url>` form and a two-step `wget`/`curl` download + `sudo pacman -U ./yconn-VERSION-1-x86_64.pkg.tar.zst` form; Debian/Ubuntu section is updated with a `wget`/`curl` download command and `sudo dpkg -i yconn_VERSION_amd64.deb` (or `sudo apt install ./yconn_VERSION_amd64.deb`) install step; all URLs use the correct `yanctab/yconn` repository (fixing the stale `mans/yconn` reference); version placeholders use a clearly-labelled variable (e.g. `VERSION=1.2.0`) so examples stay meaningful without going stale
+  - Depends on: Add make install target
+  - Modify: README.md
+  - Create: none
+  - Reuse: scripts/build-pkg.sh:OUTFILE (Arch filename pattern yconn-VERSION-1-x86_64.pkg.tar.zst), scripts/build-deb.sh:PKG (Debian filename pattern yconn_VERSION_amd64.deb)
+  - Risks: version numbers in shell examples will go stale — use a `VERSION=x.y.z` variable assignment before the download command so users only need to update one line; pacman -U with a URL fetches and installs in one step — note this requires network access


### PR DESCRIPTION
## Summary

- Adds `PREFIX ?= /usr/local` variable to the Makefile
- Adds `make install` target that depends on `build`, installs the binary to `$(PREFIX)/bin/yconn` with `install -Dm755`, and conditionally installs the man page to `$(PREFIX)/share/man/man1/yconn.1` if it has been built
- Help comment notes that `sudo` is needed for system-level prefix paths
- Updates README.md from-source section to show the full `git clone` → `make build` → `sudo make install` flow, with an alternative `make install PREFIX=~/.local` for user-level installs

## Test plan

- [ ] `make help` shows the `install` target with correct description
- [ ] `make install` exits 0 after `make build`
- [ ] Binary is present at `$(PREFIX)/bin/yconn` after install
- [ ] All 176 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)