### PR TITLE
docs: update Arch and Debian install instructions with wget/pacman steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,34 @@ Connections live in YAML files at three layers (project, user, system). Higher l
 
 ## Installation
 
-### Arch Linux (AUR)
+### Arch Linux
+
+One-step (pacman fetches and installs directly from the release URL):
+```bash
+VERSION=1.2.0
+sudo pacman -U "https://github.com/yanctab/yconn/releases/download/v${VERSION}/yconn-${VERSION}-1-x86_64.pkg.tar.zst"
 ```
-yay -S yconn
+
+Two-step (download first, then install):
+```bash
+VERSION=1.2.0
+wget "https://github.com/yanctab/yconn/releases/download/v${VERSION}/yconn-${VERSION}-1-x86_64.pkg.tar.zst"
+sudo pacman -U "yconn-${VERSION}-1-x86_64.pkg.tar.zst"
+```
+
+Or with curl:
+```bash
+VERSION=1.2.0
+curl -LO "https://github.com/yanctab/yconn/releases/download/v${VERSION}/yconn-${VERSION}-1-x86_64.pkg.tar.zst"
+sudo pacman -U "yconn-${VERSION}-1-x86_64.pkg.tar.zst"
 ```
 
 ### Debian / Ubuntu
-Download the latest `.deb` from the [releases page](https://github.com/mans/yconn/releases) and install:
-```
-sudo dpkg -i yconn_0.1.0_amd64.deb
+
+```bash
+VERSION=1.2.0
+wget "https://github.com/yanctab/yconn/releases/download/v${VERSION}/yconn_${VERSION}_amd64.deb"
+sudo apt install "./yconn_${VERSION}_amd64.deb"
 ```
 
 ### From source

--- a/TASKS.md
+++ b/TASKS.md
@@ -111,7 +111,7 @@
   - Reuse: Makefile:BINARY (name extraction), Makefile:build (dependency), packaging/aur/PKGBUILD.template (install -Dm755 pattern)
   - Risks: man page install must be conditional on `docs/man/$(BINARY).1` existing (make docs may not have been run); help comment should mention `sudo make install` for /usr/local; do not hardcode /usr/local — use PREFIX variable
 
-- [ ] **Update README installation instructions for Arch and Debian pre-built packages** [docs] S
+- [x] **Update README installation instructions for Arch and Debian pre-built packages** [docs] S
   - Acceptance: Arch Linux section replaces `yay -S yconn` with both a one-step `sudo pacman -U <github-release-url>` form and a two-step `wget`/`curl` download + `sudo pacman -U ./yconn-VERSION-1-x86_64.pkg.tar.zst` form; Debian/Ubuntu section is updated with a `wget`/`curl` download command and `sudo dpkg -i yconn_VERSION_amd64.deb` (or `sudo apt install ./yconn_VERSION_amd64.deb`) install step; all URLs use the correct `yanctab/yconn` repository (fixing the stale `mans/yconn` reference); version placeholders use a clearly-labelled variable (e.g. `VERSION=1.2.0`) so examples stay meaningful without going stale
   - Depends on: Add make install target
   - Modify: README.md


### PR DESCRIPTION
## Summary

- Replaces `yay -S yconn` with direct `.pkg.tar.zst` install instructions: one-step `pacman -U <url>` and two-step `wget`/`curl` + `pacman -U ./file`
- Replaces the hardcoded Debian `dpkg -i` snippet with `wget` + `sudo apt install ./file.deb` (apt preferred as it handles dependencies)
- All examples use a `VERSION=x.y.z` variable so only one line needs updating per release
- Fixes stale `mans/yconn` release URL → `yanctab/yconn`

## Test plan

- [ ] README renders correctly on GitHub — all code blocks display cleanly
- [ ] Arch section shows both one-step (`pacman -U <url>`) and two-step (`wget` + `pacman -U ./file`) forms
- [ ] Debian section shows `wget` download + `sudo apt install ./file.deb`
- [ ] All version references point to `yanctab/yconn`
- [ ] All 176 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)