### PR TITLE
feat(packaging): add make setup target for developer bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 
-.PHONY: build install lint fmt fmt-check test coverage clean release package docs publish help
+.PHONY: build install setup lint fmt fmt-check test coverage clean release package docs publish help
 
 BINARY := $(shell grep '^name' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
@@ -10,6 +10,15 @@ PREFIX ?= /usr/local
 ## help - show available targets
 help:
 	@grep -E '^## [a-zA-Z_-]+ - ' Makefile | awk 'BEGIN {FS=" - "} {printf "  %-15s %s\n", substr($$1, 4), $$2}'
+
+## setup - install Rust toolchain components and cargo-llvm-cov for local development
+setup:
+	rustup component add rustfmt clippy llvm-tools-preview
+	rustup target add x86_64-unknown-linux-musl
+	cargo install cargo-llvm-cov --locked
+	@echo ""
+	@echo "System packages required (install manually):"
+	@echo "  sudo apt-get install -y musl-tools pandoc zstd"
 
 ## build - compile a static musl release binary
 build:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ Global flags: `--layer system|user|project`, `--all`, `--verbose`, `--no-color`
 
 ## Development
 
-```
+```bash
+# First-time setup (installs Rust components and cargo-llvm-cov)
+make setup
+# System packages also required:
+sudo apt-get install -y musl-tools pandoc zstd
+
 make build    # compile (musl static binary)
 make test     # run tests
 make lint     # cargo fmt --check + clippy

--- a/TASKS.md
+++ b/TASKS.md
@@ -127,7 +127,7 @@
   - Reuse: Makefile:test (target to extend with coverage call), .github/workflows/ci.yml:dtolnay/rust-toolchain (add llvm-tools-preview component)
   - Risks: `cargo-llvm-cov` must be installed on both CI and local machines — CI step must run `cargo install cargo-llvm-cov --locked` before `make test`; the musl TARGET in the Makefile is not used by `make test` (plain `cargo test`), so llvm-cov should work without musl flags; adding coverage as last step of test means a cold dev machine without the tool will fail `make test` — acceptable if the error message is clear
 
-- [ ] **Add make setup target for developer environment bootstrap** [packaging] S
+- [x] **Add make setup target for developer environment bootstrap** [packaging] S
   - Acceptance: `make setup` installs all Rust toolchain prerequisites in one command: runs `rustup component add rustfmt clippy llvm-tools-preview`, `rustup target add x86_64-unknown-linux-musl`, and `cargo install cargo-llvm-cov --locked`; it also prints a note listing the required system packages (`musl-tools`, `pandoc`, `zstd`) with the apt install command for reference, since those cannot be installed without sudo in a portable way; `make help` shows the setup target with an accurate description; README.md Development section documents `make setup` as the first step for new contributors, followed by the system package install command
   - Depends on: Add make coverage target and call it from make test
   - Modify: Makefile, README.md


### PR DESCRIPTION
## Summary

- Adds `make setup` target that installs all Rust toolchain prerequisites in one command: `rustup component add rustfmt clippy llvm-tools-preview`, `rustup target add x86_64-unknown-linux-musl`, and `cargo install cargo-llvm-cov --locked`
- Prints a reminder for system packages (`sudo apt-get install -y musl-tools pandoc zstd`) that require sudo
- Updates README.md Development section to show `make setup` as the first step for new contributors

## Test plan

- [ ] `make help` shows the `setup` target with correct description
- [ ] `make setup` completes without error on a clean environment
- [ ] System package hint is printed at the end
- [ ] All 176 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)