### PR TITLE
feat(packaging): auto-install system deps with distro detection in make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,12 @@ PREFIX ?= /usr/local
 help:
 	@grep -E '^## [a-zA-Z_-]+ - ' Makefile | awk 'BEGIN {FS=" - "} {printf "  %-15s %s\n", substr($$1, 4), $$2}'
 
-## setup - install Rust toolchain components and cargo-llvm-cov for local development
+## setup - install Rust toolchain components, cargo-llvm-cov, and system deps (distro auto-detected)
 setup:
+	./scripts/install-deps.sh
 	rustup component add rustfmt clippy llvm-tools-preview
 	rustup target add x86_64-unknown-linux-musl
 	cargo install cargo-llvm-cov --locked
-	@echo ""
-	@echo "System packages required (install manually):"
-	@echo "  sudo apt-get install -y musl-tools pandoc zstd"
 
 ## build - compile a static musl release binary
 build:

--- a/TASKS.md
+++ b/TASKS.md
@@ -134,3 +134,11 @@
   - Create: none
   - Reuse: .github/workflows/release.yml (exact apt packages: musl-tools pandoc zstd; exact rustup target: x86_64-unknown-linux-musl), .github/workflows/ci.yml (rustfmt clippy components)
   - Risks: system package install cannot be automated portably — print the apt command as a hint rather than running it; all rustup and cargo install commands are idempotent so re-running setup is safe; cargo install may be slow on first run — acceptable for a one-time setup target
+
+- [x] **Auto-install system dependencies in make setup using distro detection** [packaging] S
+  - Acceptance: `scripts/install-deps.sh` detects the Linux distribution from `/etc/os-release` (`ID` and `ID_LIKE` fields) and installs the required system packages automatically — `sudo apt-get install -y musl-tools pandoc zstd` on Debian/Ubuntu/derivatives, `sudo pacman -S --noconfirm musl pandoc zstd` on Arch Linux; if the distro is unsupported the script exits 1 with a clear message listing the packages to install manually; `make setup` calls `scripts/install-deps.sh` instead of printing the static apt hint; `make test` passes
+  - Depends on: Add make setup target for developer environment bootstrap
+  - Modify: Makefile
+  - Create: scripts/install-deps.sh
+  - Reuse: scripts/build-pkg.sh (set -euo pipefail pattern), .github/workflows/release.yml (Debian package names: musl-tools pandoc zstd)
+  - Risks: script requires sudo — will prompt for password interactively; Arch package name is `musl` not `musl-tools`; `/etc/os-release` ID_LIKE check needed for Ubuntu (ID=ubuntu, ID_LIKE=debian) and derivatives like Mint; script must be chmod +x

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install required system packages for building yconn, with distro detection.
+set -euo pipefail
+
+if [[ ! -f /etc/os-release ]]; then
+    echo "Cannot detect distribution: /etc/os-release not found."
+    echo "Please install manually: musl-tools (or musl), pandoc, zstd"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source /etc/os-release
+
+ID="${ID:-}"
+ID_LIKE="${ID_LIKE:-}"
+
+is_debian_like() {
+    [[ "$ID" == "debian" || "$ID" == "ubuntu" ]] && return 0
+    [[ "$ID_LIKE" == *"debian"* || "$ID_LIKE" == *"ubuntu"* ]] && return 0
+    return 1
+}
+
+is_arch_like() {
+    [[ "$ID" == "arch" ]] && return 0
+    [[ "$ID_LIKE" == *"arch"* ]] && return 0
+    return 1
+}
+
+if is_debian_like; then
+    echo "Detected Debian/Ubuntu-based distribution: $ID"
+    sudo apt-get install -y musl-tools pandoc zstd
+elif is_arch_like; then
+    echo "Detected Arch Linux-based distribution: $ID"
+    sudo pacman -S --noconfirm musl pandoc zstd
+else
+    echo "Unsupported distribution: $ID. Please install manually: musl-tools (or musl), pandoc, zstd"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/install-deps.sh` that detects the Linux distribution via `/etc/os-release` and installs the required system packages automatically
  - Debian/Ubuntu/derivatives: `sudo apt-get install -y musl-tools pandoc zstd`
  - Arch Linux/derivatives: `sudo pacman -S --noconfirm musl pandoc zstd`
  - Unsupported distros: prints a clear message listing packages to install manually and exits 1
- Updates `make setup` to call `scripts/install-deps.sh` instead of printing a static apt hint
- All 176 tests pass, coverage at 90.78%

## Test plan

- [ ] `make setup` on Debian/Ubuntu installs packages via apt-get
- [ ] `make setup` on Arch installs packages via pacman
- [ ] Running on an unsupported distro prints a helpful message and exits 1
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)