### PR TITLE
Set 0o600 permissions on config files created by yconn

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -224,6 +224,24 @@ fn write_entry(target: &Path, name: &str, entry: &str) -> Result<()> {
             .with_context(|| format!("failed to write {}", target.display()))?;
     }
 
+    set_private_permissions(target)?;
+
+    Ok(())
+}
+
+/// Set 0o600 permissions on `path` so it is not world-readable.
+///
+/// This is a no-op on non-Unix platforms where the concept does not apply.
+#[cfg(unix)]
+fn set_private_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -498,5 +516,52 @@ mod tests {
     fn test_entry_exists_returns_false_when_absent() {
         let content = "connections:\n  other:\n    host: h\n";
         assert!(!entry_exists(content, "myconn"));
+    }
+
+    // ── file permissions ──────────────────────────────────────────────────────
+
+    #[test]
+    #[cfg(unix)]
+    fn test_add_new_file_has_0o600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let answers = [
+            "srv", "1.2.3.4", "root", "", "key", "~/.ssh/k", "Server", "",
+        ];
+        run_with_input(Layer::User, dir.path(), &answers).unwrap();
+        let target = dir.path().join("connections.yaml");
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "new config file should have 0o600 permissions");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_add_existing_file_has_0o600_permissions_after_append() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("connections.yaml");
+        // Write initial content with looser permissions to simulate existing file.
+        fs::write(
+            &target,
+            "version: 1\n\nconnections:\n  existing:\n    host: h\n    user: u\n    auth: key\n    description: \"d\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let answers = [
+            "newconn",
+            "2.2.2.2",
+            "user2",
+            "",
+            "password",
+            "New server",
+            "",
+        ];
+        run_with_input(Layer::User, dir.path(), &answers).unwrap();
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "updated config file should have 0o600 permissions"
+        );
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -59,6 +59,8 @@ pub(crate) fn run_impl(cwd: &std::path::Path, group: &str) -> Result<()> {
     std::fs::write(&target, TEMPLATE)
         .with_context(|| format!("failed to write {}", target.display()))?;
 
+    set_private_permissions(&target)?;
+
     println!("Created {}", canonicalize_display(&target).display());
     println!("Edit it to add connections, then run `yconn list` to verify.");
 
@@ -69,6 +71,22 @@ pub(crate) fn run_impl(cwd: &std::path::Path, group: &str) -> Result<()> {
 /// `canonicalize` fails (e.g. on a tempdir that has been removed).
 fn canonicalize_display(path: &std::path::Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Set 0o600 permissions on `path` so it is not world-readable.
+///
+/// No-op on non-Unix platforms.
+#[cfg(unix)]
+fn set_private_permissions(path: &std::path::Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_permissions(_path: &std::path::Path) -> anyhow::Result<()> {
+    Ok(())
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -128,5 +146,17 @@ mod tests {
         run_impl(dir.path(), "connections").unwrap();
 
         assert!(yconn.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_init_file_has_0o600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), "connections").unwrap();
+
+        let target = dir.path().join(".yconn").join("connections.yaml");
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "init file should have 0o600 permissions");
     }
 }

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -96,6 +96,24 @@ pub(crate) fn write_session_at(path: &Path, group: Option<&str>) -> Result<()> {
 
     std::fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
 
+    set_private_permissions(path)?;
+
+    Ok(())
+}
+
+/// Set 0o600 permissions on `path` so it is not world-readable.
+///
+/// No-op on non-Unix platforms.
+#[cfg(unix)]
+fn set_private_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -262,6 +280,32 @@ mod tests {
         write_session_at(&path, Some("private")).unwrap();
         let ag = read_session_at(&path).unwrap();
         assert_eq!(ag.name, "private");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_write_session_file_has_0o600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        write_session_at(&path, Some("work")).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "session.yml should have 0o600 permissions");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_write_session_clear_file_has_0o600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.yml");
+        write_session_at(&path, Some("work")).unwrap();
+        write_session_at(&path, None).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "session.yml should have 0o600 permissions after clear"
+        );
     }
 
     // ── group discovery ───────────────────────────────────────────────────────


### PR DESCRIPTION
Implements task: Set 0o600 permissions on config files created by yconn