### PR TITLE
Replace per-file group system with inline `group` field on connections

### DIFF
--- a/.claude/current-task
+++ b/.claude/current-task
@@ -1,1 +1,1 @@
-Expand `~` in key paths before file existence and permission checks
+Replace per-file group system with inline `group` field on connections

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -58,11 +58,8 @@ pub(crate) fn run_impl(
     input: &mut dyn BufRead,
     output: &mut dyn Write,
 ) -> Result<()> {
-    let group = crate::group::active_group()
-        .context("cannot determine active group")?
-        .name;
-
-    let target = layer_dir.join(format!("{group}.yaml"));
+    // Always write to connections.yaml — groups are inline fields, not per-file.
+    let target = layer_dir.join("connections.yaml");
 
     writeln!(
         output,

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -60,7 +60,7 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
     }
 
     #[test]

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -114,7 +114,7 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
     }
 
     fn argv(args: &[&str]) -> Vec<String> {

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -101,7 +101,7 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
     }
 
     // ── resolve_path ──────────────────────────────────────────────────────────

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -1,10 +1,10 @@
 // Handlers for `yconn group` subcommands:
-//   list    — show all groups found across all layers
-//   use     — set the active group (persisted to ~/.config/yconn/session.yml)
-//   clear   — remove active_group from session.yml, revert to default
+//   list    — show all groups found across all connections
+//   use     — set the active group lock (persisted to ~/.config/yconn/session.yml)
+//   clear   — remove active_group from session.yml, revert to no lock
 //   current — print the active group name and its resolved config file paths
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
@@ -12,21 +12,7 @@ use crate::config::LoadedConfig;
 use crate::display::{GroupCurrentStatus, GroupRow, LayerCurrentInfo, Renderer};
 
 pub fn list(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
-    let user_dir = dirs::config_dir().map(|d| d.join("yconn"));
-    let system_dir = PathBuf::from("/etc/yconn");
-
-    // Build the list of (dir, label) pairs in priority order.
-    let mut dirs: Vec<(PathBuf, &str)> = Vec::new();
-    if let Some(ref pd) = cfg.project_dir {
-        dirs.push((pd.clone(), "project"));
-    }
-    if let Some(ref ud) = user_dir {
-        dirs.push((ud.clone(), "user"));
-    }
-    dirs.push((system_dir, "system"));
-
-    let dir_refs: Vec<(&Path, &str)> = dirs.iter().map(|(p, l)| (p.as_path(), *l)).collect();
-    let groups = crate::group::discover_groups(&dir_refs)?;
+    let groups = cfg.discover_groups();
 
     let rows: Vec<GroupRow> = groups
         .iter()
@@ -65,33 +51,21 @@ pub fn current(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
     Ok(())
 }
 
-/// Set the active group and warn if no config file for it exists in any layer.
+/// Set the active group lock and warn if no connections with that group value
+/// exist in any layer.
 ///
-/// The group is always written even if no config file exists — the user can
-/// follow up with `yconn init` to create one.
+/// The group is always written even if no connections use it — the user can
+/// follow up with `yconn add` to tag connections with this group.
 pub fn use_group(name: &str, cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
     let session_path = dirs::config_dir()
         .context("cannot determine user config directory")?
         .join("yconn")
         .join("session.yml");
 
-    let user_dir = dirs::config_dir().map(|d| d.join("yconn"));
-    let system_dir = PathBuf::from("/etc/yconn");
-
-    let mut dirs: Vec<(PathBuf, &str)> = Vec::new();
-    if let Some(ref pd) = cfg.project_dir {
-        dirs.push((pd.clone(), "project"));
-    }
-    if let Some(ref ud) = user_dir {
-        dirs.push((ud.clone(), "user"));
-    }
-    dirs.push((system_dir, "system"));
-
-    let dir_refs: Vec<(&Path, &str)> = dirs.iter().map(|(p, l)| (p.as_path(), *l)).collect();
-    use_group_impl(name, &session_path, &dir_refs, renderer)
+    use_group_impl(name, &session_path, cfg, renderer)
 }
 
-/// Remove `active_group` from `session.yml`, reverting to the default group.
+/// Remove `active_group` from `session.yml`, reverting to no group lock.
 pub fn clear() -> Result<()> {
     let session_path = dirs::config_dir()
         .context("cannot determine user config directory")?
@@ -105,15 +79,17 @@ pub fn clear() -> Result<()> {
 fn use_group_impl(
     name: &str,
     session_path: &Path,
-    layer_dirs: &[(&Path, &str)],
+    cfg: &LoadedConfig,
     renderer: &Renderer,
 ) -> Result<()> {
     crate::group::write_session_at(session_path, Some(name))?;
 
-    let groups = crate::group::discover_groups(layer_dirs)?;
+    // Warn if no connections in any layer carry this group tag.
+    let groups = cfg.discover_groups();
     if !groups.iter().any(|g| g.name == name) {
         renderer.warn(&format!(
-            "group '{name}' has no config file in any layer — create one with 'yconn init'"
+            "group '{name}' has no connections tagged with it in any layer — \
+             tag connections with 'group: {name}' or use 'yconn add'"
         ));
     }
 
@@ -149,62 +125,74 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, None, false, user, sys).unwrap()
+    }
+
+    fn simple_conn(name: &str, host: &str) -> String {
+        format!(
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n"
+        )
+    }
+
+    fn conn_with_group(name: &str, host: &str, group: &str) -> String {
+        format!(
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n    group: {group}\n"
+        )
     }
 
     // ── group list ────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_group_list_no_error() {
-        let root = TempDir::new().unwrap();
-        let yconn = root.path().join(".yconn");
-        fs::create_dir_all(&yconn).unwrap();
-        write_yaml(&yconn, "connections.yaml", "connections: {}\n");
-
-        let empty = TempDir::new().unwrap();
-        let cfg = load(root.path(), None, empty.path());
-        // project_dir is set when .yconn/connections.yaml exists
-        assert!(cfg.project_dir.is_some());
-        list(&cfg, &no_color()).unwrap();
-    }
-
-    #[test]
-    fn test_group_list_no_project_dir_no_error() {
+    fn test_group_list_no_error_empty() {
         let cwd = TempDir::new().unwrap();
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), None, empty.path());
-        assert!(cfg.project_dir.is_none());
         list(&cfg, &no_color()).unwrap();
     }
 
     #[test]
-    fn test_group_list_groups_discovered_from_project() {
-        let root = TempDir::new().unwrap();
-        let yconn = root.path().join(".yconn");
-        fs::create_dir_all(&yconn).unwrap();
-        write_yaml(&yconn, "connections.yaml", "connections: {}\n");
-        write_yaml(&yconn, "work.yaml", "connections: {}\n");
-
+    fn test_group_list_shows_groups_from_connections() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &conn_with_group("work-srv", "10.0.0.1", "work"),
+        );
         let empty = TempDir::new().unwrap();
-        let cfg = load(root.path(), None, empty.path());
-        // Discover manually to verify the expected groups exist.
-        let dirs = [(yconn.as_path(), "project")];
-        let groups = crate::group::discover_groups(&dirs).unwrap();
-        let names: Vec<&str> = groups.iter().map(|g| g.name.as_str()).collect();
-        assert!(names.contains(&"connections"));
-        assert!(names.contains(&"work"));
+        let cfg = load(cwd.path(), Some(user.path()), empty.path());
+        // Should find "work" group from inline field
+        let groups = cfg.discover_groups();
+        assert!(!groups.is_empty());
+        assert!(groups.iter().any(|g| g.name == "work"));
+        list(&cfg, &no_color()).unwrap();
+    }
 
+    #[test]
+    fn test_group_list_connections_without_group_field_not_shown() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &simple_conn("plain-srv", "10.0.0.1"),
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(cwd.path(), Some(user.path()), empty.path());
+        // Connections without a group field don't appear in group list
+        let groups = cfg.discover_groups();
+        assert!(groups.is_empty());
         list(&cfg, &no_color()).unwrap();
     }
 
     // ── group current ─────────────────────────────────────────────────────────
 
     #[test]
-    fn test_group_current_default_group_no_error() {
+    fn test_group_current_no_lock_no_error() {
         let cwd = TempDir::new().unwrap();
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), None, empty.path());
-        assert_eq!(cfg.group, "connections");
+        assert!(cfg.group.is_none());
         current(&cfg, &no_color()).unwrap();
     }
 
@@ -214,14 +202,20 @@ mod tests {
         let user = TempDir::new().unwrap();
         write_yaml(
             user.path(),
-            "work.yaml",
-            "connections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
+            "connections.yaml",
+            &conn_with_group("work-srv", "10.0.0.1", "work"),
         );
         let empty = TempDir::new().unwrap();
-        // Explicitly request the "work" group (as if session.yml said so)
-        let cfg =
-            config::load_impl(cwd.path(), "work", true, Some(user.path()), empty.path()).unwrap();
-        assert_eq!(cfg.group, "work");
+        // Explicitly request the "work" group lock (as if session.yml said so)
+        let cfg = config::load_impl(
+            cwd.path(),
+            Some("work"),
+            true,
+            Some(user.path()),
+            empty.path(),
+        )
+        .unwrap();
+        assert_eq!(cfg.group.as_deref(), Some("work"));
         assert!(cfg.group_from_file);
         current(&cfg, &no_color()).unwrap();
     }
@@ -247,38 +241,30 @@ mod tests {
 
     // ── group use ─────────────────────────────────────────────────────────────
 
-    /// Switch group: session.yml is written with the new group name.
+    /// Switch group: session.yml is written with the new group lock.
     #[test]
     fn test_use_group_writes_session() {
         let session_dir = TempDir::new().unwrap();
         let session_path = session_dir.path().join("session.yml");
 
-        let layer_dir = TempDir::new().unwrap();
-        write_yaml(layer_dir.path(), "work.yaml", "connections: {}\n");
-        let dirs = [(layer_dir.path(), "user")];
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &conn_with_group("work-srv", "10.0.0.1", "work"),
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(
+            TempDir::new().unwrap().path(),
+            Some(user.path()),
+            empty.path(),
+        );
 
-        use_group_impl("work", &session_path, &dirs, &no_color()).unwrap();
+        use_group_impl("work", &session_path, &cfg, &no_color()).unwrap();
 
         let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, "work");
+        assert_eq!(ag.name.as_deref(), Some("work"));
         assert!(ag.from_file);
-    }
-
-    /// Subsequent config loads use the new group after use_group writes session.
-    #[test]
-    fn test_use_group_subsequent_load_uses_new_group() {
-        let session_dir = TempDir::new().unwrap();
-        let session_path = session_dir.path().join("session.yml");
-
-        let layer_dir = TempDir::new().unwrap();
-        write_yaml(layer_dir.path(), "work.yaml", "connections: {}\n");
-        let dirs = [(layer_dir.path(), "user")];
-
-        use_group_impl("work", &session_path, &dirs, &no_color()).unwrap();
-
-        // Reading back directly confirms the group was persisted.
-        let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, "work");
     }
 
     /// Use unknown group: warning emitted but operation still succeeds and
@@ -288,57 +274,48 @@ mod tests {
         let session_dir = TempDir::new().unwrap();
         let session_path = session_dir.path().join("session.yml");
 
-        let empty_layer = TempDir::new().unwrap();
-        let dirs = [(empty_layer.path(), "user")];
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        // Empty config — no connections with any group
+        let cfg = load(cwd.path(), None, empty.path());
 
-        // Must return Ok — warning is emitted but group is still set.
-        let result = use_group_impl("no-such-group", &session_path, &dirs, &no_color());
+        // Must return Ok — warning is emitted but group lock is still set.
+        let result = use_group_impl("no-such-group", &session_path, &cfg, &no_color());
         assert!(result.is_ok());
 
         // Session was written despite the warning.
         let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, "no-such-group");
+        assert_eq!(ag.name.as_deref(), Some("no-such-group"));
     }
 
-    /// Use group that exists in one layer but not another: still succeeds with
-    /// no warning because at least one layer has the file.
+    /// Use group that exists in connections: no warning, session written.
     #[test]
-    fn test_use_group_missing_in_some_layers_still_succeeds() {
+    fn test_use_group_existing_group_no_warning() {
         let session_dir = TempDir::new().unwrap();
         let session_path = session_dir.path().join("session.yml");
 
-        let project_dir = TempDir::new().unwrap();
-        write_yaml(project_dir.path(), "work.yaml", "connections: {}\n");
-        let system_dir = TempDir::new().unwrap(); // work.yaml absent in system layer
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &conn_with_group("work-srv", "10.0.0.1", "work"),
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(
+            TempDir::new().unwrap().path(),
+            Some(user.path()),
+            empty.path(),
+        );
 
-        let dirs = [
-            (project_dir.path(), "project"),
-            (system_dir.path(), "system"),
-        ];
-
-        use_group_impl("work", &session_path, &dirs, &no_color()).unwrap();
-
-        let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, "work");
-    }
-
-    /// Use group with no layer dirs at all: behaves like unknown group (warning,
-    /// session written).
-    #[test]
-    fn test_use_group_no_dirs_does_not_block() {
-        let session_dir = TempDir::new().unwrap();
-        let session_path = session_dir.path().join("session.yml");
-
-        let result = use_group_impl("work", &session_path, &[], &no_color());
-        assert!(result.is_ok());
+        use_group_impl("work", &session_path, &cfg, &no_color()).unwrap();
 
         let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, "work");
+        assert_eq!(ag.name.as_deref(), Some("work"));
     }
 
     // ── group clear ───────────────────────────────────────────────────────────
 
-    /// Clear group: active_group is removed from session.yml, reverts to default.
+    /// Clear group: active_group is removed from session.yml, reverts to no lock.
     #[test]
     fn test_clear_removes_active_group() {
         let session_dir = TempDir::new().unwrap();
@@ -347,13 +324,13 @@ mod tests {
         // Write a group first.
         group::write_session_at(&session_path, Some("work")).unwrap();
         let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, "work");
+        assert_eq!(ag.name.as_deref(), Some("work"));
 
         // Clear it.
         clear_impl(&session_path).unwrap();
 
         let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, group::DEFAULT_GROUP);
+        assert!(ag.name.is_none());
         assert!(!ag.from_file);
     }
 
@@ -364,6 +341,6 @@ mod tests {
         // File does not exist — clear should still succeed.
         clear_impl(&session_path).unwrap();
         let ag = group::read_session_at(&session_path).unwrap();
-        assert_eq!(ag.name, group::DEFAULT_GROUP);
+        assert!(ag.name.is_none());
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -33,18 +33,16 @@ connections:
 // ─── Public entry point ───────────────────────────────────────────────────────
 
 pub fn run() -> Result<()> {
-    let group = crate::group::active_group()
-        .context("cannot determine active group")?
-        .name;
     let cwd = std::env::current_dir().context("cannot determine current directory")?;
-    run_impl(&cwd, &group)
+    run_impl(&cwd)
 }
 
 // ─── Testable impl ────────────────────────────────────────────────────────────
 
-pub(crate) fn run_impl(cwd: &std::path::Path, group: &str) -> Result<()> {
+pub(crate) fn run_impl(cwd: &std::path::Path) -> Result<()> {
     let yconn_dir = cwd.join(".yconn");
-    let target = yconn_dir.join(format!("{group}.yaml"));
+    // Always scaffold connections.yaml — groups are inline fields, not per-file.
+    let target = yconn_dir.join("connections.yaml");
 
     if target.exists() {
         anyhow::bail!(
@@ -100,7 +98,7 @@ mod tests {
     #[test]
     fn test_init_creates_yconn_dir_and_file() {
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path(), "connections").unwrap();
+        run_impl(dir.path()).unwrap();
 
         let target = dir.path().join(".yconn").join("connections.yaml");
         assert!(target.exists(), "config file should be created");
@@ -109,7 +107,7 @@ mod tests {
     #[test]
     fn test_init_file_contains_template_markers() {
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path(), "connections").unwrap();
+        run_impl(dir.path()).unwrap();
 
         let content =
             fs::read_to_string(dir.path().join(".yconn").join("connections.yaml")).unwrap();
@@ -118,12 +116,13 @@ mod tests {
     }
 
     #[test]
-    fn test_init_uses_active_group_name() {
+    fn test_init_always_creates_connections_yaml() {
+        // init always scaffolds connections.yaml — groups are inline fields, not per-file.
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path(), "work").unwrap();
+        run_impl(dir.path()).unwrap();
 
-        let target = dir.path().join(".yconn").join("work.yaml");
-        assert!(target.exists(), "file should use the active group name");
+        let target = dir.path().join(".yconn").join("connections.yaml");
+        assert!(target.exists(), "init must always create connections.yaml");
     }
 
     #[test]
@@ -133,7 +132,7 @@ mod tests {
         fs::create_dir_all(&yconn).unwrap();
         fs::write(yconn.join("connections.yaml"), "connections: {}\n").unwrap();
 
-        let err = run_impl(dir.path(), "connections").unwrap_err();
+        let err = run_impl(dir.path()).unwrap_err();
         assert!(err.to_string().contains("already exists"));
     }
 
@@ -143,7 +142,7 @@ mod tests {
         let yconn = dir.path().join(".yconn");
         assert!(!yconn.exists());
 
-        run_impl(dir.path(), "connections").unwrap();
+        run_impl(dir.path()).unwrap();
 
         assert!(yconn.exists());
     }
@@ -153,7 +152,7 @@ mod tests {
     fn test_init_file_has_0o600_permissions() {
         use std::os::unix::fs::PermissionsExt;
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path(), "connections").unwrap();
+        run_impl(dir.path()).unwrap();
 
         let target = dir.path().join(".yconn").join("connections.yaml");
         let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -61,7 +61,7 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
     }
 
     #[test]

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -224,7 +224,7 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
     }
 
     fn run_with_input(

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -52,7 +52,7 @@ mod tests {
         user: Option<&std::path::Path>,
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
-        config::load_impl(cwd, "connections", false, user, sys).unwrap()
+        config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,9 +1,13 @@
 //! Config layer loading, upward walk, and merge logic.
 //!
-//! Loads `<group>.yaml` from three layers in priority order (project >
+//! Loads `connections.yaml` from three layers in priority order (project >
 //! user > system), merges into a flat connection map with source tracking,
 //! and retains shadowed entries for `--all` display. Surfaces the resolved
 //! `docker` block when present.
+//!
+//! Groups are now inline: each connection may carry an optional `group` field.
+//! The active group (stored in `session.yml`) acts as a filter on the merged
+//! connection list, not as a file-name selector.
 
 // Public API is consumed by CLI command modules not yet implemented.
 #![allow(dead_code)]
@@ -51,6 +55,10 @@ struct RawConn {
     description: String,
     #[serde(default)]
     link: Option<String>,
+    /// Optional inline group tag. Connections without a `group:` field belong
+    /// to no group and are always shown unless a group filter is active.
+    #[serde(default)]
+    group: Option<String>,
 }
 
 fn default_port() -> u16 {
@@ -88,6 +96,8 @@ pub struct Connection {
     pub key: Option<String>,
     pub description: String,
     pub link: Option<String>,
+    /// Optional inline group tag from the YAML `group:` field.
+    pub group: Option<String>,
     /// The layer this entry was loaded from.
     pub layer: Layer,
     /// Path to the config file that defines this entry.
@@ -110,7 +120,7 @@ pub struct DockerConfig {
 #[derive(Debug)]
 pub struct LayerStatus {
     pub layer: Layer,
-    /// Path that was (or would be) loaded for this group and layer.
+    /// Path that was (or would be) loaded for this layer.
     pub path: PathBuf,
     /// `None` = file not found; `Some(n)` = number of connections in the file.
     pub connection_count: Option<usize>,
@@ -120,6 +130,8 @@ pub struct LayerStatus {
 #[derive(Debug)]
 pub struct LoadedConfig {
     /// Active connections — one per name, highest-priority layer wins.
+    /// This always contains the full unfiltered set; callers apply group
+    /// filtering via the helper methods.
     pub connections: Vec<Connection>,
     /// Active + shadowed connections interleaved for `--all` display.
     /// Shadowed entries appear immediately after their active counterpart.
@@ -132,8 +144,9 @@ pub struct LoadedConfig {
     pub project_dir: Option<PathBuf>,
     /// Security warnings collected during loading.
     pub warnings: Vec<security::Warning>,
-    /// The active group name.
-    pub group: String,
+    /// The active group name (locked group from session.yml), if any.
+    /// `None` means no lock — show all connections by default.
+    pub group: Option<String>,
     /// `true` = group was read from `session.yml`; `false` = using the default.
     pub group_from_file: bool,
 }
@@ -142,6 +155,73 @@ impl LoadedConfig {
     /// Find a connection by name (active connections only).
     pub fn find(&self, name: &str) -> Option<&Connection> {
         self.connections.iter().find(|c| c.name == name)
+    }
+
+    /// Return the connections that should be shown by default.
+    ///
+    /// - If `group_filter` is `Some(name)`, return only connections whose
+    ///   `group` field equals `name`.
+    /// - If `group_filter` is `None`, return all active connections.
+    ///
+    /// The `group_filter` may come from `--group <name>` (CLI flag, highest
+    /// priority) or from the locked group in `session.yml`.
+    pub fn filtered_connections(&self, group_filter: Option<&str>) -> Vec<&Connection> {
+        match group_filter {
+            Some(g) => self
+                .connections
+                .iter()
+                .filter(|c| c.group.as_deref() == Some(g))
+                .collect(),
+            None => self.connections.iter().collect(),
+        }
+    }
+
+    /// Determine the effective group filter to apply for `yconn list`.
+    ///
+    /// Precedence (highest to lowest):
+    ///   1. `--all` flag → no filter (returns `None`)
+    ///   2. `--group <name>` CLI flag → `Some(name)`
+    ///   3. Locked group from `session.yml` → `Some(name)`
+    ///   4. Default → no filter (`None`)
+    pub fn effective_group_filter<'a>(
+        &'a self,
+        all_flag: bool,
+        group_flag: Option<&'a str>,
+    ) -> Option<&'a str> {
+        if all_flag {
+            return None;
+        }
+        if let Some(g) = group_flag {
+            return Some(g);
+        }
+        self.group.as_deref()
+    }
+
+    /// Return unique group values present across all active connections.
+    /// Used by `yconn group list`.
+    pub fn discover_groups(&self) -> Vec<crate::group::GroupEntry> {
+        use std::collections::BTreeMap;
+        // BTreeMap keeps groups sorted by name for stable output.
+        let mut map: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+        for conn in &self.connections {
+            if let Some(ref g) = conn.group {
+                let layer_label = conn.layer.label().to_string();
+                map.entry(g.clone()).or_default().push(layer_label.clone());
+            }
+        }
+
+        // Deduplicate layer labels while preserving insertion order.
+        map.into_iter()
+            .map(|(name, raw_layers)| {
+                let mut seen = std::collections::HashSet::new();
+                let layers: Vec<String> = raw_layers
+                    .into_iter()
+                    .filter(|l| seen.insert(l.clone()))
+                    .collect();
+                crate::group::GroupEntry { name, layers }
+            })
+            .collect()
     }
 }
 
@@ -163,7 +243,7 @@ pub fn load_from(cwd: &Path) -> Result<LoadedConfig> {
     let system_dir = PathBuf::from("/etc/yconn");
     load_impl(
         cwd,
-        &ag.name,
+        ag.name.as_deref(),
         ag.from_file,
         user_dir.as_deref(),
         &system_dir,
@@ -177,9 +257,12 @@ type RawLayer = (Vec<(String, RawConn)>, Layer, PathBuf);
 
 /// Core load logic with all paths explicit — used directly by tests and
 /// command-layer integration tests.
+///
+/// `group` is now `Option<&str>`: `None` means no lock (show all by default),
+/// `Some(name)` means a group is locked in session.yml.
 pub(crate) fn load_impl(
     cwd: &Path,
-    group: &str,
+    group: Option<&str>,
     group_from_file: bool,
     user_dir: Option<&Path>,
     system_dir: &Path,
@@ -187,9 +270,10 @@ pub(crate) fn load_impl(
     let mut warnings: Vec<security::Warning> = Vec::new();
 
     // ── Resolve paths ────────────────────────────────────────────────────────
-    let (project_dir, project_file) = upward_walk(cwd, group);
-    let user_file = user_dir.map(|d| d.join(format!("{group}.yaml")));
-    let system_file = system_dir.join(format!("{group}.yaml"));
+    // Always load from `connections.yaml` — groups are inline fields now.
+    let (project_dir, project_file) = upward_walk(cwd);
+    let user_file = user_dir.map(|d| d.join("connections.yaml"));
+    let system_file = system_dir.join("connections.yaml");
 
     // ── Load each layer ──────────────────────────────────────────────────────
     let proj = load_layer(project_file.as_deref(), Layer::Project, true, &mut warnings)?;
@@ -241,14 +325,14 @@ pub(crate) fn load_impl(
             layer: Layer::Project,
             path: project_file
                 .clone()
-                .unwrap_or_else(|| PathBuf::from(format!(".yconn/{group}.yaml"))),
+                .unwrap_or_else(|| PathBuf::from(".yconn/connections.yaml")),
             connection_count: proj.found.then_some(proj.count),
         },
         LayerStatus {
             layer: Layer::User,
             path: user_file
                 .clone()
-                .unwrap_or_else(|| PathBuf::from(format!("~/.config/yconn/{group}.yaml"))),
+                .unwrap_or_else(|| PathBuf::from("~/.config/yconn/connections.yaml")),
             connection_count: user.found.then_some(user.count),
         },
         LayerStatus {
@@ -265,7 +349,7 @@ pub(crate) fn load_impl(
         layers,
         project_dir,
         warnings,
-        group: group.to_string(),
+        group: group.map(str::to_owned),
         group_from_file,
     })
 }
@@ -337,18 +421,17 @@ fn load_layer(
 
 // ─── Upward walk ─────────────────────────────────────────────────────────────
 
-/// Walk upward from `cwd` looking for `.yconn/<group>.yaml`, stopping at
+/// Walk upward from `cwd` looking for `.yconn/connections.yaml`, stopping at
 /// `$HOME` or the filesystem root.
 ///
 /// Returns `(yconn_dir, config_file)` when found, `(None, None)` otherwise.
-fn upward_walk(cwd: &Path, group: &str) -> (Option<PathBuf>, Option<PathBuf>) {
+fn upward_walk(cwd: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
     let home = dirs::home_dir();
-    let filename = format!("{group}.yaml");
     let mut dir = cwd.to_path_buf();
 
     loop {
         let yconn_dir = dir.join(".yconn");
-        let config_file = yconn_dir.join(&filename);
+        let config_file = yconn_dir.join("connections.yaml");
         if config_file.exists() {
             return (Some(yconn_dir), Some(config_file));
         }
@@ -425,6 +508,7 @@ fn build_connection(
         key: raw.key.clone(),
         description: raw.description.clone(),
         link: raw.link.clone(),
+        group: raw.group.clone(),
         layer,
         source_path: path.to_path_buf(),
         shadowed,
@@ -463,8 +547,23 @@ mod tests {
         )
     }
 
+    fn conn_with_group(name: &str, host: &str, group: &str) -> String {
+        format!(
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n    group: {group}\n"
+        )
+    }
+
     fn load_test(cwd: &Path, user_dir: Option<&Path>, system_dir: &Path) -> LoadedConfig {
-        load_impl(cwd, "connections", false, user_dir, system_dir).unwrap()
+        load_impl(cwd, None, false, user_dir, system_dir).unwrap()
+    }
+
+    fn load_test_with_group(
+        cwd: &Path,
+        user_dir: Option<&Path>,
+        system_dir: &Path,
+        group: Option<&str>,
+    ) -> LoadedConfig {
+        load_impl(cwd, group, group.is_some(), user_dir, system_dir).unwrap()
     }
 
     // ── upward walk ───────────────────────────────────────────────────────────
@@ -479,7 +578,7 @@ mod tests {
         let nested = root.path().join("a").join("b").join("c");
         fs::create_dir_all(&nested).unwrap();
 
-        let (dir, file) = upward_walk(&nested, "connections");
+        let (dir, file) = upward_walk(&nested);
         assert_eq!(dir.unwrap(), yconn);
         assert!(file.unwrap().exists());
     }
@@ -487,7 +586,7 @@ mod tests {
     #[test]
     fn test_upward_walk_no_config() {
         let dir = TempDir::new().unwrap();
-        let (d, f) = upward_walk(dir.path(), "connections");
+        let (d, f) = upward_walk(dir.path());
         assert!(d.is_none());
         assert!(f.is_none());
     }
@@ -513,7 +612,7 @@ mod tests {
             &simple_conn("inner", "2.2.2.2"),
         );
 
-        let (_, file) = upward_walk(&inner, "connections");
+        let (_, file) = upward_walk(&inner);
         let content = fs::read_to_string(file.unwrap()).unwrap();
         assert!(content.contains("inner"));
     }
@@ -955,5 +1054,196 @@ mod tests {
         assert_eq!(cfg.layers[0].connection_count, None); // project not found
         assert_eq!(cfg.layers[1].connection_count, Some(2)); // user: 2 connections
         assert_eq!(cfg.layers[2].connection_count, None); // system not found
+    }
+
+    // ── inline group field ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_group_field_round_trip() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &conn_with_group("work-srv", "10.0.0.1", "work"),
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let conn = cfg.find("work-srv").unwrap();
+        assert_eq!(conn.group.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn test_group_field_absent_is_none() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &simple_conn("srv", "1.2.3.4"),
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let conn = cfg.find("srv").unwrap();
+        assert!(conn.group.is_none());
+    }
+
+    // ── group filtering ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_filtered_connections_no_filter() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        let yaml = format!(
+            "{}\n{}",
+            conn_with_group("work-srv", "10.0.0.1", "work"),
+            // Simple conn in same connections block — just append raw
+            "  plain-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n"
+        );
+        write_yaml(user.path(), "connections.yaml", &yaml);
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        // No filter → all connections returned
+        let filtered = cfg.filtered_connections(None);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn test_filtered_connections_with_group_filter() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        let yaml = format!(
+            "{}\n{}",
+            conn_with_group("work-srv", "10.0.0.1", "work"),
+            "  plain-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n"
+        );
+        write_yaml(user.path(), "connections.yaml", &yaml);
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        // Filter by "work" group → only work-srv returned
+        let filtered = cfg.filtered_connections(Some("work"));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "work-srv");
+    }
+
+    #[test]
+    fn test_effective_group_filter_all_overrides_everything() {
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        let cfg = load_test_with_group(cwd.path(), None, empty.path(), Some("work"));
+        // --all overrides locked group
+        assert_eq!(cfg.effective_group_filter(true, None), None);
+    }
+
+    #[test]
+    fn test_effective_group_filter_group_flag_overrides_lock() {
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        let cfg = load_test_with_group(cwd.path(), None, empty.path(), Some("work"));
+        // --group private overrides locked "work"
+        assert_eq!(
+            cfg.effective_group_filter(false, Some("private")),
+            Some("private")
+        );
+    }
+
+    #[test]
+    fn test_effective_group_filter_locked_group_used() {
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        let cfg = load_test_with_group(cwd.path(), None, empty.path(), Some("work"));
+        // No --all, no --group flag → locked group used
+        assert_eq!(cfg.effective_group_filter(false, None), Some("work"));
+    }
+
+    #[test]
+    fn test_effective_group_filter_no_lock_no_flags() {
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        let cfg = load_test(cwd.path(), None, empty.path());
+        // No lock, no flags → None (show all)
+        assert_eq!(cfg.effective_group_filter(false, None), None);
+    }
+
+    // ── discover_groups ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_discover_groups_empty() {
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        let cfg = load_test(cwd.path(), None, empty.path());
+        let groups = cfg.discover_groups();
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_discover_groups_from_connections() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        let yaml = format!(
+            "{}\n{}",
+            conn_with_group("work-srv", "10.0.0.1", "work"),
+            "  private-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n    group: private\n"
+        );
+        write_yaml(user.path(), "connections.yaml", &yaml);
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let groups = cfg.discover_groups();
+        assert_eq!(groups.len(), 2);
+        let names: Vec<&str> = groups.iter().map(|g| g.name.as_str()).collect();
+        assert!(names.contains(&"work"));
+        assert!(names.contains(&"private"));
+    }
+
+    #[test]
+    fn test_discover_groups_sorted_by_name() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        let yaml = format!(
+            "{}\n{}",
+            conn_with_group("z-srv", "10.0.0.1", "zebra"),
+            "  a-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n    group: alpha\n"
+        );
+        write_yaml(user.path(), "connections.yaml", &yaml);
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let groups = cfg.discover_groups();
+        let names: Vec<&str> = groups.iter().map(|g| g.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "zebra"]);
+    }
+
+    #[test]
+    fn test_discover_groups_tracks_layers() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            &conn_with_group("p-srv", "10.0.0.1", "work"),
+        );
+
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            &conn_with_group("u-srv", "10.0.0.2", "work"),
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(root.path(), Some(user.path()), empty.path());
+        let groups = cfg.discover_groups();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].name, "work");
+        // Both project and user layers have a "work" connection
+        let layers = &groups[0].layers;
+        assert!(layers.contains(&"project".to_string()));
+        assert!(layers.contains(&"user".to_string()));
     }
 }

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -114,6 +114,7 @@ mod tests {
             key: key.map(str::to_string),
             description: String::new(),
             link: None,
+            group: None,
             layer: Layer::User,
             source_path: PathBuf::from("test.yaml"),
             shadowed: false,

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -52,7 +52,8 @@ pub struct DockerInfo {
 
 /// Full status for `yconn config`.
 pub struct ConfigStatus {
-    pub group: String,
+    /// The locked group name, or `None` when no group is locked.
+    pub group: Option<String>,
     /// `true` = read from `session.yml`; `false` = using the default.
     pub group_from_file: bool,
     pub layers: Vec<LayerInfo>,
@@ -74,7 +75,8 @@ pub struct LayerCurrentInfo {
 
 /// Full status for `yconn group current`.
 pub struct GroupCurrentStatus {
-    pub active_group: String,
+    /// The locked group name, or `None` when no group is locked.
+    pub active_group: Option<String>,
     pub session_file: String,
     pub layers: Vec<LayerCurrentInfo>,
 }
@@ -270,13 +272,19 @@ impl Renderer {
         const LABEL_W: usize = 9;
         let mut out = String::new();
 
-        if status.group_from_file {
-            out.push_str(&format!(
-                "Group:   {}  (set in ~/.config/yconn/session.yml)\n",
-                status.group
-            ));
-        } else {
-            out.push_str(&format!("Group:   {}  (default)\n", status.group));
+        match &status.group {
+            Some(g) if status.group_from_file => {
+                out.push_str(&format!(
+                    "Group:   {}  (set in ~/.config/yconn/session.yml)\n",
+                    g
+                ));
+            }
+            Some(g) => {
+                out.push_str(&format!("Group:   {}  (default)\n", g));
+            }
+            None => {
+                out.push_str("Group:   (none — showing all connections)\n");
+            }
         }
         out.push('\n');
 
@@ -363,7 +371,11 @@ impl Renderer {
         const LABEL_W: usize = 9; // "[project]" is 9 chars
         let mut out = String::new();
 
-        out.push_str(&format!("Active group: {}\n", status.active_group));
+        let group_display = status
+            .active_group
+            .as_deref()
+            .unwrap_or("(none — showing all connections)");
+        out.push_str(&format!("Active group: {}\n", group_display));
         out.push_str(&format!("Lock file:    {}\n", status.session_file));
         out.push('\n');
         out.push_str("Resolved config files:\n");
@@ -675,7 +687,7 @@ mod tests {
     #[test]
     fn test_config_status_default_group_no_docker() {
         let status = ConfigStatus {
-            group: "connections".into(),
+            group: Some("connections".to_string()),
             group_from_file: false,
             layers: vec![
                 LayerInfo {
@@ -708,7 +720,7 @@ mod tests {
     #[test]
     fn test_config_status_from_file_with_docker() {
         let status = ConfigStatus {
-            group: "work".into(),
+            group: Some("work".to_string()),
             group_from_file: true,
             layers: vec![LayerInfo {
                 label: "project".into(),
@@ -770,7 +782,7 @@ mod tests {
     #[test]
     fn test_group_current_found_and_not_found() {
         let status = GroupCurrentStatus {
-            active_group: "work".into(),
+            active_group: Some("work".to_string()),
             session_file: "~/.config/yconn/session.yml".into(),
             layers: vec![
                 LayerCurrentInfo {

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -1,38 +1,35 @@
 //! Active group resolution and session.yml read/write.
 //!
 //! Reads and writes `~/.config/yconn/session.yml`. Resolves the active group
-//! name (defaulting to `"connections"` when the file is absent or the key is
-//! unset). Scans layer directories to discover which groups have config files,
-//! used by `yconn group list`.
+//! name (defaulting to `None` when the file is absent or the key is unset,
+//! meaning "no group lock — show all connections by default").
+//!
+//! Group discovery is now performed by `LoadedConfig::discover_groups()` which
+//! scans the inline `group:` fields on connection entries rather than scanning
+//! the filesystem for named YAML files.
 
 // Public API is consumed by CLI command modules not yet implemented.
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-// ─── Public constants ─────────────────────────────────────────────────────────
-
-/// The group name used when no `active_group` is set in `session.yml`.
-pub const DEFAULT_GROUP: &str = "connections";
-
 // ─── Public types ─────────────────────────────────────────────────────────────
 
-/// The resolved active group and whether it came from `session.yml`.
+/// The resolved active group lock and whether it came from `session.yml`.
 pub struct ActiveGroup {
-    /// The group name (never empty; defaults to [`DEFAULT_GROUP`]).
-    pub name: String,
+    /// The locked group name, or `None` when no group is locked (show all).
+    pub name: Option<String>,
     /// `true` = read from `session.yml`; `false` = using the built-in default.
     pub from_file: bool,
 }
 
-/// A group discovered by scanning layer config directories.
+/// A group discovered by scanning connection `group:` fields across all layers.
 pub struct GroupEntry {
     pub name: String,
-    /// Which layers have a config file for this group (e.g. `["project", "user"]`).
+    /// Which layers contain connections tagged with this group.
     pub layers: Vec<String>,
 }
 
@@ -60,7 +57,7 @@ fn session_path() -> Result<PathBuf> {
 pub(crate) fn read_session_at(path: &Path) -> Result<ActiveGroup> {
     if !path.exists() {
         return Ok(ActiveGroup {
-            name: DEFAULT_GROUP.into(),
+            name: None,
             from_file: false,
         });
     }
@@ -73,11 +70,11 @@ pub(crate) fn read_session_at(path: &Path) -> Result<ActiveGroup> {
 
     match file.active_group.filter(|s| !s.is_empty()) {
         Some(name) => Ok(ActiveGroup {
-            name,
+            name: Some(name),
             from_file: true,
         }),
         None => Ok(ActiveGroup {
-            name: DEFAULT_GROUP.into(),
+            name: None,
             from_file: false,
         }),
     }
@@ -117,44 +114,12 @@ fn set_private_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn discover_in_dirs(dirs: &[(&Path, &str)]) -> Result<Vec<GroupEntry>> {
-    // BTreeMap keeps groups sorted by name for stable output.
-    let mut map: BTreeMap<String, Vec<String>> = BTreeMap::new();
-
-    for (dir, layer_label) in dirs {
-        let entries = match std::fs::read_dir(dir) {
-            Ok(e) => e,
-            Err(_) => continue, // directory absent or unreadable — skip silently
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
-                continue;
-            }
-            let stem = match path.file_stem().and_then(|s| s.to_str()) {
-                Some(s) => s.to_string(),
-                None => continue,
-            };
-            // Skip the session state file — it is not a group config.
-            if stem == "session" {
-                continue;
-            }
-            map.entry(stem).or_default().push(layer_label.to_string());
-        }
-    }
-
-    Ok(map
-        .into_iter()
-        .map(|(name, layers)| GroupEntry { name, layers })
-        .collect())
-}
-
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-/// Return the active group, reading `session.yml` via the standard path.
+/// Return the active group lock, reading `session.yml` via the standard path.
 ///
-/// Returns `DEFAULT_GROUP` when the file is absent or `active_group` is unset.
+/// Returns `name: None` when the file is absent or `active_group` is unset,
+/// meaning no group is locked and all connections should be shown by default.
 pub fn active_group() -> Result<ActiveGroup> {
     read_session_at(&session_path()?)
 }
@@ -164,21 +129,9 @@ pub fn set_active_group(name: &str) -> Result<()> {
     write_session_at(&session_path()?, Some(name))
 }
 
-/// Remove `active_group` from `session.yml`, reverting to the default.
+/// Remove `active_group` from `session.yml`, reverting to the default (no lock).
 pub fn clear_active_group() -> Result<()> {
     write_session_at(&session_path()?, None)
-}
-
-/// Scan `dirs` — each `(directory, layer_label)` pair — and return all groups
-/// found across them.
-///
-/// The caller is responsible for building the directory list (including the
-/// project-layer path obtained from the upward walk). Directories that do not
-/// exist are silently skipped.
-///
-/// Results are sorted by group name.
-pub fn discover_groups(dirs: &[(&Path, &str)]) -> Result<Vec<GroupEntry>> {
-    discover_in_dirs(dirs)
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -196,7 +149,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("session.yml");
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(ag.name.is_none());
         assert!(!ag.from_file);
     }
 
@@ -206,7 +159,7 @@ mod tests {
         let path = dir.path().join("session.yml");
         fs::write(&path, "active_group: work\n").unwrap();
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, "work");
+        assert_eq!(ag.name.as_deref(), Some("work"));
         assert!(ag.from_file);
     }
 
@@ -216,7 +169,7 @@ mod tests {
         let path = dir.path().join("session.yml");
         fs::write(&path, "active_group: \"\"\n").unwrap();
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(ag.name.is_none());
         assert!(!ag.from_file);
     }
 
@@ -226,7 +179,7 @@ mod tests {
         let path = dir.path().join("session.yml");
         fs::write(&path, "").unwrap();
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(ag.name.is_none());
         assert!(!ag.from_file);
     }
 
@@ -236,7 +189,7 @@ mod tests {
         let path = dir.path().join("session.yml");
         fs::write(&path, "active_group: staging\nsome_future_key: 42\n").unwrap();
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, "staging");
+        assert_eq!(ag.name.as_deref(), Some("staging"));
         assert!(ag.from_file);
     }
 
@@ -250,7 +203,7 @@ mod tests {
         write_session_at(&path, Some("work")).unwrap();
         assert!(path.exists());
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, "work");
+        assert_eq!(ag.name.as_deref(), Some("work"));
     }
 
     #[test]
@@ -268,7 +221,7 @@ mod tests {
         write_session_at(&path, Some("work")).unwrap();
         write_session_at(&path, None).unwrap();
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, DEFAULT_GROUP);
+        assert!(ag.name.is_none());
         assert!(!ag.from_file);
     }
 
@@ -279,7 +232,7 @@ mod tests {
         write_session_at(&path, Some("work")).unwrap();
         write_session_at(&path, Some("private")).unwrap();
         let ag = read_session_at(&path).unwrap();
-        assert_eq!(ag.name, "private");
+        assert_eq!(ag.name.as_deref(), Some("private"));
     }
 
     #[test]
@@ -306,89 +259,5 @@ mod tests {
             mode, 0o600,
             "session.yml should have 0o600 permissions after clear"
         );
-    }
-
-    // ── group discovery ───────────────────────────────────────────────────────
-
-    #[test]
-    fn test_discover_no_dirs() {
-        let groups = discover_in_dirs(&[]).unwrap();
-        assert!(groups.is_empty());
-    }
-
-    #[test]
-    fn test_discover_missing_dirs_silently_skipped() {
-        let dir = TempDir::new().unwrap();
-        let absent = dir.path().join("does-not-exist");
-        let groups = discover_in_dirs(&[(&absent, "project")]).unwrap();
-        assert!(groups.is_empty());
-    }
-
-    #[test]
-    fn test_discover_single_layer() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("connections.yaml"), "").unwrap();
-        fs::write(dir.path().join("work.yaml"), "").unwrap();
-        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
-        assert_eq!(groups.len(), 2);
-        let connections = groups.iter().find(|g| g.name == "connections").unwrap();
-        assert_eq!(connections.layers, vec!["user"]);
-        let work = groups.iter().find(|g| g.name == "work").unwrap();
-        assert_eq!(work.layers, vec!["user"]);
-    }
-
-    #[test]
-    fn test_discover_multiple_layers_same_group() {
-        let project = TempDir::new().unwrap();
-        let user = TempDir::new().unwrap();
-        let system = TempDir::new().unwrap();
-
-        fs::write(project.path().join("work.yaml"), "").unwrap();
-        fs::write(user.path().join("work.yaml"), "").unwrap();
-        fs::write(system.path().join("connections.yaml"), "").unwrap();
-
-        let groups = discover_in_dirs(&[
-            (project.path(), "project"),
-            (user.path(), "user"),
-            (system.path(), "system"),
-        ])
-        .unwrap();
-
-        let work = groups.iter().find(|g| g.name == "work").unwrap();
-        assert_eq!(work.layers, vec!["project", "user"]);
-
-        let connections = groups.iter().find(|g| g.name == "connections").unwrap();
-        assert_eq!(connections.layers, vec!["system"]);
-    }
-
-    #[test]
-    fn test_discover_skips_session_file() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("session.yml"), "").unwrap();
-        fs::write(dir.path().join("connections.yaml"), "").unwrap();
-        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
-        assert_eq!(groups.len(), 1);
-        assert_eq!(groups[0].name, "connections");
-    }
-
-    #[test]
-    fn test_discover_skips_non_yaml_files() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("connections.yaml"), "").unwrap();
-        fs::write(dir.path().join("README.md"), "").unwrap();
-        fs::write(dir.path().join("notes.txt"), "").unwrap();
-        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
-        assert_eq!(groups.len(), 1);
-    }
-
-    #[test]
-    fn test_discover_results_sorted_by_name() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("work.yaml"), "").unwrap();
-        fs::write(dir.path().join("connections.yaml"), "").unwrap();
-        fs::write(dir.path().join("private.yaml"), "").unwrap();
-        let groups = discover_in_dirs(&[(dir.path(), "user")]).unwrap();
-        let names: Vec<&str> = groups.iter().map(|g| g.name.as_str()).collect();
-        assert_eq!(names, vec!["connections", "private", "work"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,15 +75,12 @@ fn load_and_warn(renderer: &display::Renderer, verbose: bool) -> Result<config::
         renderer.warn(&w.message);
     }
     if verbose {
-        renderer.verbose(&format!(
-            "Active group: {} ({})",
-            cfg.group,
-            if cfg.group_from_file {
-                "from session.yml"
-            } else {
-                "default"
-            }
-        ));
+        let group_desc = match &cfg.group {
+            Some(g) if cfg.group_from_file => format!("{g} (from session.yml)"),
+            Some(g) => format!("{g} (default)"),
+            None => "none (showing all connections)".to_string(),
+        };
+        renderer.verbose(&format!("Active group: {group_desc}"));
         for l in &cfg.layers {
             renderer.verbose(&format!(
                 "[{}] {} — {}",


### PR DESCRIPTION
Implements task: Replace per-file group system with inline `group` field on connections