### PR TITLE
Support multiple project config filename conventions with 

### DIFF
--- a/.claude/current-task
+++ b/.claude/current-task
@@ -1,1 +1,1 @@
-Replace per-file group system with inline `group` field on connections
+Support multiple project config filename conventions with `yconn init --location`

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,7 @@
 // Parses commands and flags, delegates entirely to other modules.
 // No business logic lives here.
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 /// yconn — SSH connection manager
 #[derive(Debug, Parser)]
@@ -28,6 +28,21 @@ pub struct Cli {
 
     #[command(subcommand)]
     pub command: Commands,
+}
+
+/// Where `yconn init` places the scaffolded config file.
+///
+/// - `yconn` (default): `.yconn/connections.yaml` — recommended, git-trackable
+/// - `dotfile`:         `.connections.yaml` in the current directory
+/// - `plain`:           `connections.yaml` in the current directory (may clash with other tools)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum InitLocation {
+    /// Scaffold `.yconn/connections.yaml` (default, backward compatible)
+    Yconn,
+    /// Scaffold `.connections.yaml` in the current directory
+    Dotfile,
+    /// Scaffold `connections.yaml` in the current directory
+    Plain,
 }
 
 #[derive(Debug, Subcommand)]
@@ -62,8 +77,18 @@ pub enum Commands {
         name: String,
     },
 
-    /// Scaffold a <group>.yaml in .yconn/ in the current directory
-    Init,
+    /// Scaffold a connections.yaml in the current directory
+    Init {
+        /// Where to place the scaffolded config file.
+        ///
+        /// yconn  → .yconn/connections.yaml (default, git-trackable, recommended)
+        ///
+        /// dotfile → .connections.yaml in cwd
+        ///
+        /// plain   → connections.yaml in cwd (may clash with other tools)
+        #[arg(long, value_enum, default_value = "yconn")]
+        location: InitLocation,
+    },
 
     /// Show which config files are active, their paths, and Docker status
     Config,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,10 +1,12 @@
 // src/commands/init.rs
-// Handler for `yconn init` — scaffold a <group>.yaml in .yconn/ in the
-// current directory.
+// Handler for `yconn init` — scaffold a connections.yaml in the current
+// directory, at the location specified by `--location`.
 
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+
+use crate::cli::InitLocation;
 
 // ─── Template ────────────────────────────────────────────────────────────────
 
@@ -32,17 +34,15 @@ connections:
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
-pub fn run() -> Result<()> {
+pub fn run(location: InitLocation) -> Result<()> {
     let cwd = std::env::current_dir().context("cannot determine current directory")?;
-    run_impl(&cwd)
+    run_impl(&cwd, location)
 }
 
 // ─── Testable impl ────────────────────────────────────────────────────────────
 
-pub(crate) fn run_impl(cwd: &std::path::Path) -> Result<()> {
-    let yconn_dir = cwd.join(".yconn");
-    // Always scaffold connections.yaml — groups are inline fields, not per-file.
-    let target = yconn_dir.join("connections.yaml");
+pub(crate) fn run_impl(cwd: &std::path::Path, location: InitLocation) -> Result<()> {
+    let target = resolve_target(cwd, location);
 
     if target.exists() {
         anyhow::bail!(
@@ -51,8 +51,11 @@ pub(crate) fn run_impl(cwd: &std::path::Path) -> Result<()> {
         );
     }
 
-    std::fs::create_dir_all(&yconn_dir)
-        .with_context(|| format!("failed to create directory {}", yconn_dir.display()))?;
+    // Create parent directory if needed (only .yconn/ for the default location).
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
 
     std::fs::write(&target, TEMPLATE)
         .with_context(|| format!("failed to write {}", target.display()))?;
@@ -63,6 +66,19 @@ pub(crate) fn run_impl(cwd: &std::path::Path) -> Result<()> {
     println!("Edit it to add connections, then run `yconn list` to verify.");
 
     Ok(())
+}
+
+/// Resolve the target file path from `cwd` and the chosen location.
+///
+/// - `InitLocation::Yconn`   → `<cwd>/.yconn/connections.yaml`
+/// - `InitLocation::Dotfile` → `<cwd>/.connections.yaml`
+/// - `InitLocation::Plain`   → `<cwd>/connections.yaml`
+pub(crate) fn resolve_target(cwd: &std::path::Path, location: InitLocation) -> PathBuf {
+    match location {
+        InitLocation::Yconn => cwd.join(".yconn").join("connections.yaml"),
+        InitLocation::Dotfile => cwd.join(".connections.yaml"),
+        InitLocation::Plain => cwd.join("connections.yaml"),
+    }
 }
 
 /// Return a canonical display path, falling back to the original if
@@ -95,19 +111,21 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    // ── default location (yconn) ──────────────────────────────────────────────
+
     #[test]
-    fn test_init_creates_yconn_dir_and_file() {
+    fn test_init_yconn_creates_yconn_dir_and_file() {
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path()).unwrap();
+        run_impl(dir.path(), InitLocation::Yconn).unwrap();
 
         let target = dir.path().join(".yconn").join("connections.yaml");
         assert!(target.exists(), "config file should be created");
     }
 
     #[test]
-    fn test_init_file_contains_template_markers() {
+    fn test_init_yconn_file_contains_template_markers() {
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path()).unwrap();
+        run_impl(dir.path(), InitLocation::Yconn).unwrap();
 
         let content =
             fs::read_to_string(dir.path().join(".yconn").join("connections.yaml")).unwrap();
@@ -116,46 +134,145 @@ mod tests {
     }
 
     #[test]
-    fn test_init_always_creates_connections_yaml() {
-        // init always scaffolds connections.yaml — groups are inline fields, not per-file.
-        let dir = TempDir::new().unwrap();
-        run_impl(dir.path()).unwrap();
-
-        let target = dir.path().join(".yconn").join("connections.yaml");
-        assert!(target.exists(), "init must always create connections.yaml");
-    }
-
-    #[test]
-    fn test_init_fails_if_file_already_exists() {
-        let dir = TempDir::new().unwrap();
-        let yconn = dir.path().join(".yconn");
-        fs::create_dir_all(&yconn).unwrap();
-        fs::write(yconn.join("connections.yaml"), "connections: {}\n").unwrap();
-
-        let err = run_impl(dir.path()).unwrap_err();
-        assert!(err.to_string().contains("already exists"));
-    }
-
-    #[test]
-    fn test_init_creates_yconn_dir_when_absent() {
+    fn test_init_yconn_creates_yconn_dir_when_absent() {
         let dir = TempDir::new().unwrap();
         let yconn = dir.path().join(".yconn");
         assert!(!yconn.exists());
 
-        run_impl(dir.path()).unwrap();
+        run_impl(dir.path(), InitLocation::Yconn).unwrap();
 
         assert!(yconn.exists());
     }
 
     #[test]
+    fn test_init_yconn_fails_if_file_already_exists() {
+        let dir = TempDir::new().unwrap();
+        let yconn = dir.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        fs::write(yconn.join("connections.yaml"), "connections: {}\n").unwrap();
+
+        let err = run_impl(dir.path(), InitLocation::Yconn).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    // ── dotfile location ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_init_dotfile_creates_file_in_cwd() {
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), InitLocation::Dotfile).unwrap();
+
+        let target = dir.path().join(".connections.yaml");
+        assert!(target.exists(), ".connections.yaml should be created");
+    }
+
+    #[test]
+    fn test_init_dotfile_file_contains_template_markers() {
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), InitLocation::Dotfile).unwrap();
+
+        let content = fs::read_to_string(dir.path().join(".connections.yaml")).unwrap();
+        assert!(content.contains("connections:"));
+        assert!(content.contains("version: 1"));
+    }
+
+    #[test]
+    fn test_init_dotfile_fails_if_file_already_exists() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".connections.yaml"), "connections: {}\n").unwrap();
+
+        let err = run_impl(dir.path(), InitLocation::Dotfile).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    // ── plain location ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_init_plain_creates_file_in_cwd() {
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), InitLocation::Plain).unwrap();
+
+        let target = dir.path().join("connections.yaml");
+        assert!(target.exists(), "connections.yaml should be created");
+    }
+
+    #[test]
+    fn test_init_plain_file_contains_template_markers() {
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), InitLocation::Plain).unwrap();
+
+        let content = fs::read_to_string(dir.path().join("connections.yaml")).unwrap();
+        assert!(content.contains("connections:"));
+        assert!(content.contains("version: 1"));
+    }
+
+    #[test]
+    fn test_init_plain_fails_if_file_already_exists() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("connections.yaml"), "connections: {}\n").unwrap();
+
+        let err = run_impl(dir.path(), InitLocation::Plain).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    // ── resolve_target helper ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_target_yconn() {
+        let dir = TempDir::new().unwrap();
+        let target = resolve_target(dir.path(), InitLocation::Yconn);
+        assert_eq!(target, dir.path().join(".yconn").join("connections.yaml"));
+    }
+
+    #[test]
+    fn test_resolve_target_dotfile() {
+        let dir = TempDir::new().unwrap();
+        let target = resolve_target(dir.path(), InitLocation::Dotfile);
+        assert_eq!(target, dir.path().join(".connections.yaml"));
+    }
+
+    #[test]
+    fn test_resolve_target_plain() {
+        let dir = TempDir::new().unwrap();
+        let target = resolve_target(dir.path(), InitLocation::Plain);
+        assert_eq!(target, dir.path().join("connections.yaml"));
+    }
+
+    // ── permissions ───────────────────────────────────────────────────────────
+
+    #[test]
     #[cfg(unix)]
-    fn test_init_file_has_0o600_permissions() {
+    fn test_init_yconn_file_has_0o600_permissions() {
         use std::os::unix::fs::PermissionsExt;
         let dir = TempDir::new().unwrap();
-        run_impl(dir.path()).unwrap();
+        run_impl(dir.path(), InitLocation::Yconn).unwrap();
 
         let target = dir.path().join(".yconn").join("connections.yaml");
         let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "init file should have 0o600 permissions");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_init_dotfile_has_0o600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), InitLocation::Dotfile).unwrap();
+
+        let target = dir.path().join(".connections.yaml");
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "dotfile should have 0o600 permissions");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_init_plain_has_0o600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        run_impl(dir.path(), InitLocation::Plain).unwrap();
+
+        let target = dir.path().join("connections.yaml");
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "plain file should have 0o600 permissions");
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -421,19 +421,39 @@ fn load_layer(
 
 // ─── Upward walk ─────────────────────────────────────────────────────────────
 
-/// Walk upward from `cwd` looking for `.yconn/connections.yaml`, stopping at
+/// Walk upward from `cwd` looking for a project config file, stopping at
 /// `$HOME` or the filesystem root.
 ///
-/// Returns `(yconn_dir, config_file)` when found, `(None, None)` otherwise.
+/// Checks three filename conventions per directory in priority order:
+/// 1. `.yconn/connections.yaml`
+/// 2. `.connections.yaml`
+/// 3. `connections.yaml`
+///
+/// Returns `(yconn_dir, config_file)` where `yconn_dir` is the `.yconn/`
+/// directory (used for group discovery), or `None` for the dotfile/plain
+/// conventions where no `.yconn/` dir exists.
 fn upward_walk(cwd: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
     let home = dirs::home_dir();
     let mut dir = cwd.to_path_buf();
 
     loop {
+        // Priority 1: .yconn/connections.yaml
         let yconn_dir = dir.join(".yconn");
-        let config_file = yconn_dir.join("connections.yaml");
-        if config_file.exists() {
-            return (Some(yconn_dir), Some(config_file));
+        let yconn_file = yconn_dir.join("connections.yaml");
+        if yconn_file.exists() {
+            return (Some(yconn_dir), Some(yconn_file));
+        }
+
+        // Priority 2: .connections.yaml
+        let dotfile = dir.join(".connections.yaml");
+        if dotfile.exists() {
+            return (None, Some(dotfile));
+        }
+
+        // Priority 3: connections.yaml
+        let plain = dir.join("connections.yaml");
+        if plain.exists() {
+            return (None, Some(plain));
         }
 
         // Stop at $HOME (don't walk into personal dirs above the project).
@@ -589,6 +609,82 @@ mod tests {
         let (d, f) = upward_walk(dir.path());
         assert!(d.is_none());
         assert!(f.is_none());
+    }
+
+    #[test]
+    fn test_upward_walk_finds_dotfile_convention() {
+        let root = TempDir::new().unwrap();
+        let dotfile = root.path().join(".connections.yaml");
+        fs::write(&dotfile, simple_conn("srv", "1.2.3.4")).unwrap();
+
+        let nested = root.path().join("sub");
+        fs::create_dir_all(&nested).unwrap();
+
+        let (dir, file) = upward_walk(&nested);
+        assert!(dir.is_none(), "no .yconn dir for dotfile convention");
+        assert_eq!(file.unwrap(), dotfile);
+    }
+
+    #[test]
+    fn test_upward_walk_finds_plain_convention() {
+        let root = TempDir::new().unwrap();
+        let plain = root.path().join("connections.yaml");
+        fs::write(&plain, simple_conn("srv", "1.2.3.4")).unwrap();
+
+        let nested = root.path().join("sub");
+        fs::create_dir_all(&nested).unwrap();
+
+        let (dir, file) = upward_walk(&nested);
+        assert!(dir.is_none(), "no .yconn dir for plain convention");
+        assert_eq!(file.unwrap(), plain);
+    }
+
+    #[test]
+    fn test_upward_walk_yconn_beats_dotfile_same_dir() {
+        let root = TempDir::new().unwrap();
+        // Both present — .yconn/connections.yaml must win.
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            &simple_conn("yconn-srv", "1.1.1.1"),
+        );
+        fs::write(
+            root.path().join(".connections.yaml"),
+            simple_conn("dotfile-srv", "2.2.2.2"),
+        )
+        .unwrap();
+
+        let (_, file) = upward_walk(root.path());
+        let content = fs::read_to_string(file.unwrap()).unwrap();
+        assert!(
+            content.contains("yconn-srv"),
+            ".yconn convention must beat dotfile"
+        );
+    }
+
+    #[test]
+    fn test_upward_walk_dotfile_beats_plain_same_dir() {
+        let root = TempDir::new().unwrap();
+        // .connections.yaml beats connections.yaml.
+        fs::write(
+            root.path().join(".connections.yaml"),
+            simple_conn("dotfile-srv", "2.2.2.2"),
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("connections.yaml"),
+            simple_conn("plain-srv", "3.3.3.3"),
+        )
+        .unwrap();
+
+        let (_, file) = upward_walk(root.path());
+        let content = fs::read_to_string(file.unwrap()).unwrap();
+        assert!(
+            content.contains("dotfile-srv"),
+            "dotfile convention must beat plain"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
             let cfg = load_and_warn(&renderer, verbose)?;
             commands::remove::run(&cfg, &renderer, &name, cli.layer.as_deref())
         }
-        Commands::Init => commands::init::run(),
+        Commands::Init { location } => commands::init::run(location),
     }
 }
 


### PR DESCRIPTION
Implements task: Support multiple project config filename conventions with `yconn init --location`