### PR TITLE
fix(config): emit clear parse errors for malformed config files

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,14 +45,20 @@ fn default_pull() -> String {
 
 #[derive(Deserialize, Clone, Debug)]
 struct RawConn {
-    host: String,
-    user: String,
+    /// Required fields are `Option` so we can emit a clear error naming the
+    /// missing field instead of the opaque serde_yaml "missing field" message.
+    #[serde(default)]
+    host: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
     #[serde(default = "default_port")]
     port: u16,
-    auth: String,
+    #[serde(default)]
+    auth: Option<String>,
     #[serde(default)]
     key: Option<String>,
-    description: String,
+    #[serde(default)]
+    description: Option<String>,
     #[serde(default)]
     link: Option<String>,
     /// Optional inline group tag. Connections without a `group:` field belong
@@ -356,6 +362,28 @@ pub(crate) fn load_impl(
 
 // ─── Layer loading ────────────────────────────────────────────────────────────
 
+/// Validate that every connection entry in `connections` has all required
+/// fields present. Returns a clear error naming the config file, the
+/// connection entry, and the first missing required field.
+fn validate_connections(path: &Path, connections: &HashMap<String, RawConn>) -> Result<()> {
+    for (name, raw) in connections {
+        let file = path.display();
+        if raw.host.is_none() {
+            anyhow::bail!("{file}: connection '{name}' is missing required field 'host'");
+        }
+        if raw.user.is_none() {
+            anyhow::bail!("{file}: connection '{name}' is missing required field 'user'");
+        }
+        if raw.auth.is_none() {
+            anyhow::bail!("{file}: connection '{name}' is missing required field 'auth'");
+        }
+        if raw.description.is_none() {
+            anyhow::bail!("{file}: connection '{name}' is missing required field 'description'");
+        }
+    }
+    Ok(())
+}
+
 struct LayerData {
     found: bool,
     count: usize,
@@ -397,7 +425,11 @@ fn load_layer(
     }
 
     let raw: RawFile = serde_yaml::from_str(&content)
-        .with_context(|| format!("failed to parse {}", path.display()))?;
+        .with_context(|| format!("failed to parse {}: invalid YAML syntax", path.display()))?;
+
+    // Validate required connection fields — emit clear errors naming the file,
+    // connection entry, and the missing field rather than opaque serde messages.
+    validate_connections(path, &raw.connections)?;
 
     let docker_present = raw.docker.is_some();
     // User-layer docker is suppressed (caller emits the warning).
@@ -519,14 +551,16 @@ fn build_connection(
     path: &Path,
     shadowed: bool,
 ) -> Connection {
+    // SAFETY: validate_connections() is called before build_connection() in
+    // load_layer(), so all required Option fields are guaranteed to be Some.
     Connection {
         name: name.to_string(),
-        host: raw.host.clone(),
-        user: raw.user.clone(),
+        host: raw.host.clone().unwrap_or_default(),
+        user: raw.user.clone().unwrap_or_default(),
         port: raw.port,
-        auth: raw.auth.clone(),
+        auth: raw.auth.clone().unwrap_or_default(),
         key: raw.key.clone(),
-        description: raw.description.clone(),
+        description: raw.description.clone().unwrap_or_default(),
         link: raw.link.clone(),
         group: raw.group.clone(),
         layer,

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -634,6 +634,130 @@ fn edit_invokes_editor_with_correct_file_path() {
     let _ = expected_path; // path confirmed parseable via show above
 }
 
+// ─── Parse error scenarios ────────────────────────────────────────────────────
+
+/// A manually created minimal valid project config — `yconn list` shows the entry.
+#[test]
+fn parse_error_minimal_valid_project_config() {
+    let env = TestEnv::new();
+    // Write the config by hand (not using conn_key/conn_password helpers) to
+    // simulate a manually created file with all required fields present.
+    env.write_project_config(
+        "connections",
+        "connections:\n  my-server:\n    host: 10.0.0.1\n    user: admin\n    auth: password\n    description: My server\n",
+    );
+
+    let out = env.run(&["list"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("my-server"),
+        "expected 'my-server' in list output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("10.0.0.1"),
+        "expected host '10.0.0.1' in list output, got: {stdout}"
+    );
+}
+
+/// A manually created minimal valid user layer config — `yconn list` shows the entry.
+#[test]
+fn parse_error_minimal_valid_user_config() {
+    let env = TestEnv::new();
+    // Write directly to the user layer config directory.
+    env.write_user_config(
+        "connections",
+        "connections:\n  user-server:\n    host: 192.168.1.5\n    user: root\n    auth: password\n    description: User server\n",
+    );
+
+    let out = env.run(&["list"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("user-server"),
+        "expected 'user-server' in list output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("192.168.1.5"),
+        "expected host '192.168.1.5' in list output, got: {stdout}"
+    );
+}
+
+/// A connection entry missing a required field — `yconn list` exits non-zero
+/// with a clear error message naming the file, entry, and missing field.
+#[test]
+fn parse_error_missing_required_field() {
+    let env = TestEnv::new();
+    // 'host' field is intentionally absent.
+    env.write_project_config(
+        "connections",
+        "connections:\n  bad-server:\n    user: admin\n    auth: password\n    description: Missing host\n",
+    );
+
+    let out = env.run(&["list"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for missing required field, got 0"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("bad-server"),
+        "expected connection name 'bad-server' in error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("host"),
+        "expected missing field 'host' named in error, got: {stderr}"
+    );
+}
+
+/// Invalid YAML syntax — `yconn list` exits non-zero with the file name in
+/// the error message.
+#[test]
+fn parse_error_invalid_yaml_syntax() {
+    let env = TestEnv::new();
+    // Write deliberately malformed YAML.
+    env.write_project_config(
+        "connections",
+        "connections:\n  broken: [unclosed bracket\n    host: 10.0.0.1\n",
+    );
+
+    let out = env.run(&["list"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for invalid YAML, got 0"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("connections.yaml"),
+        "expected config file name 'connections.yaml' in error, got: {stderr}"
+    );
+}
+
+/// Valid YAML with an empty `connections` block — `yconn list` exits 0 and
+/// shows no connection entries (no error).
+#[test]
+fn parse_error_empty_connections_block() {
+    let env = TestEnv::new();
+    // Valid YAML but no connection entries.
+    env.write_project_config("connections", "connections:\n");
+
+    let out = env.run(&["list"]);
+    // Must exit 0 — an empty connections block is not an error.
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // No actual connection rows should appear — the output should be empty
+    // or only contain the separator line (no host names, no auth types).
+    assert!(
+        !stdout.contains("password") && !stdout.contains("key"),
+        "expected no connection rows for empty connections block, got: {stdout}"
+    );
+}
+
 // ─── Config priority scenario ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Required connection fields (`host`, `user`, `auth`, `description`) changed to `Option<String>` in `RawConn` so serde never panics on missing fields
- Added `validate_connections()` in `load_layer` that emits a clear error naming the config file path, connection name, and missing field
- Improved YAML syntax error message to include the file path

## Test plan
- [ ] `yconn list` against a config missing a required field exits non-zero with file path + connection name + field name in stderr
- [ ] `yconn list` against a file with invalid YAML exits non-zero with file name in error
- [ ] `yconn list` against a valid config with empty `connections:` block exits 0 with no rows
- [ ] All 220 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)