### PR TITLE
feat(cli): use ValueEnum for --layer flag to show valid values in --help

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,13 +6,28 @@
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+/// Which config layer to target for add / edit / remove.
+///
+/// - `system`  → `/etc/yconn/connections.yaml`
+/// - `user`    → `~/.config/yconn/connections.yaml` (default when omitted)
+/// - `project` → `.yconn/connections.yaml` in the current directory tree
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LayerArg {
+    /// System-wide layer: `/etc/yconn/connections.yaml`
+    System,
+    /// Per-user layer: `~/.config/yconn/connections.yaml` (default)
+    User,
+    /// Project layer: `.yconn/connections.yaml` in the current directory tree
+    Project,
+}
+
 /// yconn — SSH connection manager
 #[derive(Debug, Parser)]
 #[command(name = "yconn", version, about)]
 pub struct Cli {
     /// Target a specific config layer for add / edit / remove
     #[arg(long, global = true, value_name = "LAYER")]
-    pub layer: Option<String>,
+    pub layer: Option<LayerArg>,
 
     /// Include shadowed entries in list output
     #[arg(long, global = true)]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -7,12 +7,13 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
+use crate::cli::LayerArg;
 use crate::config::Layer;
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
-pub fn run(layer: Option<&str>) -> Result<()> {
-    let target_layer = resolve_layer(layer)?;
+pub fn run(layer: Option<LayerArg>) -> Result<()> {
+    let target_layer = layer_arg_to_layer(layer);
     let target_path = layer_path(target_layer)?;
 
     let stdin = io::stdin();
@@ -27,12 +28,14 @@ pub fn run(layer: Option<&str>) -> Result<()> {
 
 // ─── Layer resolution ─────────────────────────────────────────────────────────
 
-fn resolve_layer(layer: Option<&str>) -> Result<Layer> {
+/// Convert the CLI `--layer` argument to the internal [`Layer`] type.
+///
+/// When `--layer` is omitted, the default is [`Layer::User`].
+fn layer_arg_to_layer(layer: Option<LayerArg>) -> Layer {
     match layer {
-        Some("system") => Ok(Layer::System),
-        Some("user") | None => Ok(Layer::User),
-        Some("project") => Ok(Layer::Project),
-        Some(other) => bail!("unknown layer '{other}'; use system, user, or project"),
+        Some(LayerArg::System) => Layer::System,
+        Some(LayerArg::Project) => Layer::Project,
+        Some(LayerArg::User) | None => Layer::User,
     }
 }
 
@@ -297,35 +300,32 @@ mod tests {
     // ── layer resolution ──────────────────────────────────────────────────────
 
     #[test]
-    fn test_resolve_layer_none_defaults_to_user() {
-        assert!(matches!(resolve_layer(None).unwrap(), Layer::User));
+    fn test_layer_arg_none_defaults_to_user() {
+        assert!(matches!(layer_arg_to_layer(None), Layer::User));
     }
 
     #[test]
-    fn test_resolve_layer_user() {
-        assert!(matches!(resolve_layer(Some("user")).unwrap(), Layer::User));
-    }
-
-    #[test]
-    fn test_resolve_layer_project() {
+    fn test_layer_arg_user() {
         assert!(matches!(
-            resolve_layer(Some("project")).unwrap(),
+            layer_arg_to_layer(Some(LayerArg::User)),
+            Layer::User
+        ));
+    }
+
+    #[test]
+    fn test_layer_arg_project() {
+        assert!(matches!(
+            layer_arg_to_layer(Some(LayerArg::Project)),
             Layer::Project
         ));
     }
 
     #[test]
-    fn test_resolve_layer_system() {
+    fn test_layer_arg_system() {
         assert!(matches!(
-            resolve_layer(Some("system")).unwrap(),
+            layer_arg_to_layer(Some(LayerArg::System)),
             Layer::System
         ));
-    }
-
-    #[test]
-    fn test_resolve_layer_unknown_returns_error() {
-        let err = resolve_layer(Some("bogus")).unwrap_err();
-        assert!(err.to_string().contains("bogus"));
     }
 
     // ── add creates new file ──────────────────────────────────────────────────

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -7,11 +7,12 @@ use std::process::Command;
 
 use anyhow::{anyhow, bail, Context, Result};
 
+use crate::cli::LayerArg;
 use crate::config::{Layer, LoadedConfig};
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
-pub fn run(cfg: &LoadedConfig, name: &str, layer: Option<&str>) -> Result<()> {
+pub fn run(cfg: &LoadedConfig, name: &str, layer: Option<LayerArg>) -> Result<()> {
     let path = resolve_path(cfg, name, layer)?;
     open_editor(&path)
 }
@@ -22,9 +23,13 @@ pub fn run(cfg: &LoadedConfig, name: &str, layer: Option<&str>) -> Result<()> {
 ///
 /// If `--layer` is given, look for the connection in that layer only.
 /// Otherwise use the source path from the active (highest-priority) connection.
-fn resolve_path(cfg: &LoadedConfig, name: &str, layer: Option<&str>) -> Result<std::path::PathBuf> {
-    if let Some(layer_str) = layer {
-        let target_layer = parse_layer(layer_str)?;
+fn resolve_path(
+    cfg: &LoadedConfig,
+    name: &str,
+    layer: Option<LayerArg>,
+) -> Result<std::path::PathBuf> {
+    if let Some(layer_arg) = layer {
+        let target_layer = layer_arg_to_layer(layer_arg);
         // Search all_connections for the named entry in the specified layer.
         let conn = cfg
             .all_connections
@@ -45,12 +50,11 @@ fn resolve_path(cfg: &LoadedConfig, name: &str, layer: Option<&str>) -> Result<s
     }
 }
 
-fn parse_layer(s: &str) -> Result<Layer> {
-    match s {
-        "project" => Ok(Layer::Project),
-        "user" => Ok(Layer::User),
-        "system" => Ok(Layer::System),
-        other => bail!("unknown layer '{other}'; use system, user, or project"),
+fn layer_arg_to_layer(arg: LayerArg) -> Layer {
+    match arg {
+        LayerArg::Project => Layer::Project,
+        LayerArg::User => Layer::User,
+        LayerArg::System => Layer::System,
     }
 }
 
@@ -145,7 +149,7 @@ mod tests {
         assert!(p.starts_with(&yconn));
 
         // With --layer system we get the system path.
-        let p2 = resolve_path(&cfg, "srv", Some("system")).unwrap();
+        let p2 = resolve_path(&cfg, "srv", Some(LayerArg::System)).unwrap();
         assert!(p2.starts_with(sys.path()));
     }
 
@@ -173,18 +177,23 @@ mod tests {
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
 
         // 'srv' exists in user layer but not project layer.
-        let err = resolve_path(&cfg, "srv", Some("project")).unwrap_err();
+        let err = resolve_path(&cfg, "srv", Some(LayerArg::Project)).unwrap_err();
         assert!(err.to_string().contains("srv"));
         assert!(err.to_string().contains("project"));
     }
 
-    #[test]
-    fn test_resolve_path_unknown_layer_returns_error() {
-        let cwd = TempDir::new().unwrap();
-        let empty = TempDir::new().unwrap();
-        let cfg = load(cwd.path(), None, empty.path());
+    // ── layer_arg_to_layer ────────────────────────────────────────────────────
 
-        let err = resolve_path(&cfg, "srv", Some("bogus")).unwrap_err();
-        assert!(err.to_string().contains("bogus"));
+    #[test]
+    fn test_layer_arg_to_layer_all_variants() {
+        assert!(matches!(
+            layer_arg_to_layer(LayerArg::System),
+            Layer::System
+        ));
+        assert!(matches!(layer_arg_to_layer(LayerArg::User), Layer::User));
+        assert!(matches!(
+            layer_arg_to_layer(LayerArg::Project),
+            Layer::Project
+        ));
     }
 }

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -7,12 +7,18 @@ use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
 
+use crate::cli::LayerArg;
 use crate::config::{Layer, LoadedConfig};
 use crate::display::Renderer;
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
-pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str, layer: Option<&str>) -> Result<()> {
+pub fn run(
+    cfg: &LoadedConfig,
+    renderer: &Renderer,
+    name: &str,
+    layer: Option<LayerArg>,
+) -> Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     run_impl(
@@ -31,7 +37,7 @@ pub(crate) fn run_impl(
     cfg: &LoadedConfig,
     _renderer: &Renderer,
     name: &str,
-    layer: Option<&str>,
+    layer: Option<LayerArg>,
     input: &mut dyn BufRead,
     output: &mut dyn Write,
 ) -> Result<()> {
@@ -47,8 +53,8 @@ pub(crate) fn run_impl(
     }
 
     // If --layer is given, restrict to that layer only.
-    let target = if let Some(layer_str) = layer {
-        let target_layer = parse_layer(layer_str)?;
+    let target = if let Some(layer_arg) = layer {
+        let target_layer = layer_arg_to_layer(layer_arg);
         all.iter()
             .find(|c| c.layer == target_layer)
             .copied()
@@ -76,14 +82,13 @@ pub(crate) fn run_impl(
     Ok(())
 }
 
-// ─── Layer parsing ────────────────────────────────────────────────────────────
+// ─── Layer conversion ─────────────────────────────────────────────────────────
 
-fn parse_layer(s: &str) -> Result<Layer> {
-    match s {
-        "project" => Ok(Layer::Project),
-        "user" => Ok(Layer::User),
-        "system" => Ok(Layer::System),
-        other => bail!("unknown layer '{other}'; use system, user, or project"),
+fn layer_arg_to_layer(arg: LayerArg) -> Layer {
+    match arg {
+        LayerArg::Project => Layer::Project,
+        LayerArg::User => Layer::User,
+        LayerArg::System => Layer::System,
     }
 }
 
@@ -230,7 +235,7 @@ mod tests {
     fn run_with_input(
         cfg: &config::LoadedConfig,
         name: &str,
-        layer: Option<&str>,
+        layer: Option<LayerArg>,
         answers: &[&str],
     ) -> Result<String> {
         let input_str = answers.join("\n") + "\n";
@@ -322,7 +327,7 @@ mod tests {
         let cfg = load(root.path(), None, sys.path());
 
         // Remove from system layer only.
-        run_with_input(&cfg, "srv", Some("system"), &[]).unwrap();
+        run_with_input(&cfg, "srv", Some(LayerArg::System), &[]).unwrap();
 
         // Project file unchanged.
         let proj_content = fs::read_to_string(yconn.join("connections.yaml")).unwrap();
@@ -333,20 +338,19 @@ mod tests {
         assert!(!sys_content.contains("  srv:"));
     }
 
-    #[test]
-    fn test_remove_unknown_layer_returns_error() {
-        let cwd = TempDir::new().unwrap();
-        let user = TempDir::new().unwrap();
-        write_yaml(
-            user.path(),
-            "connections.yaml",
-            "connections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
-        );
-        let empty = TempDir::new().unwrap();
-        let cfg = load(cwd.path(), Some(user.path()), empty.path());
+    // ── layer_arg_to_layer ────────────────────────────────────────────────────
 
-        let err = run_with_input(&cfg, "srv", Some("bogus"), &[]).unwrap_err();
-        assert!(err.to_string().contains("bogus"));
+    #[test]
+    fn test_layer_arg_to_layer_all_variants() {
+        assert!(matches!(
+            layer_arg_to_layer(LayerArg::System),
+            Layer::System
+        ));
+        assert!(matches!(layer_arg_to_layer(LayerArg::User), Layer::User));
+        assert!(matches!(
+            layer_arg_to_layer(LayerArg::Project),
+            Layer::Project
+        ));
     }
 
     // ── ambiguous prompt ──────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,14 @@ fn main() -> Result<()> {
             let cfg = load_and_warn(&renderer, verbose)?;
             commands::connect::run(&cfg, &renderer, &name, verbose)
         }
-        Commands::Add => commands::add::run(cli.layer.as_deref()),
+        Commands::Add => commands::add::run(cli.layer),
         Commands::Edit { name } => {
             let cfg = load_and_warn(&renderer, verbose)?;
-            commands::edit::run(&cfg, &name, cli.layer.as_deref())
+            commands::edit::run(&cfg, &name, cli.layer)
         }
         Commands::Remove { name } => {
             let cfg = load_and_warn(&renderer, verbose)?;
-            commands::remove::run(&cfg, &renderer, &name, cli.layer.as_deref())
+            commands::remove::run(&cfg, &renderer, &name, cli.layer)
         }
         Commands::Init { location } => commands::init::run(location),
     }


### PR DESCRIPTION
## Summary
- Introduced `LayerArg` enum with `clap::ValueEnum` derive (following the existing `InitLocation` pattern)
- `--layer` on `add`, `edit`, and `remove` now shows `[possible values: project, system, user]` in `--help`
- Invalid `--layer` values are rejected by clap with a clear error before reaching application code
- Simplified `parse_layer`/`resolve_layer` helpers to infallible `layer_arg_to_layer` functions

## Test plan
- [ ] `yconn add --help` shows `[possible values: project, system, user]` for `--layer`
- [ ] `yconn add --layer bogus` exits with a clear clap error listing valid values
- [ ] All existing `add`, `edit`, `remove` behaviour unchanged
- [ ] All tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)