### PR TITLE
feat(connect): print full SSH command before exec when --verbose is set

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -38,6 +38,10 @@ pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str, verbose: bool) -
     }
 
     // Direct SSH path: replace the current process with ssh.
+    if verbose {
+        let ssh_args = connect::build_args(conn);
+        renderer.verbose_ssh_cmd(&ssh_args);
+    }
     connect::exec(conn)
 }
 

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -154,6 +154,120 @@ mod tests {
         assert_eq!(args, vec!["ssh", "-p", "2222", "deploy@myhost"]);
     }
 
+    // ── verbose SSH command format (same multiline format as verbose_docker_cmd) ─
+
+    /// Format args the same way `Renderer::verbose_ssh_cmd` does, so the
+    /// expected verbose output can be asserted without reaching into the
+    /// display module from connect tests.
+    fn format_verbose(args: &[String]) -> String {
+        match args.split_first() {
+            None => String::new(),
+            Some((first, rest)) => {
+                let mut line = format!("[yconn] Running: {}", first);
+                for arg in rest {
+                    line.push_str(&format!(" \\\n         {}", arg));
+                }
+                line
+            }
+        }
+    }
+
+    #[test]
+    fn test_verbose_key_auth_default_port() {
+        let conn = make_conn("key", Some("~/.ssh/id_rsa"), 22, "myhost", "deploy");
+        let args = build_args(&conn);
+        let out = format_verbose(&args);
+        assert!(
+            out.starts_with("[yconn] Running: ssh"),
+            "must start with prefix: {out}"
+        );
+        assert!(out.contains("-i"), "must include -i flag: {out}");
+        assert!(
+            out.contains("~/.ssh/id_rsa"),
+            "must include key path: {out}"
+        );
+        assert!(
+            out.contains("deploy@myhost"),
+            "must include destination: {out}"
+        );
+        assert!(
+            !out.contains("-p"),
+            "must not include port flag for default port: {out}"
+        );
+    }
+
+    #[test]
+    fn test_verbose_key_auth_custom_port() {
+        let conn = make_conn("key", Some("~/.ssh/id_rsa"), 2222, "myhost", "deploy");
+        let args = build_args(&conn);
+        let out = format_verbose(&args);
+        assert!(
+            out.starts_with("[yconn] Running: ssh"),
+            "must start with prefix: {out}"
+        );
+        assert!(out.contains("-i"), "must include -i flag: {out}");
+        assert!(
+            out.contains("~/.ssh/id_rsa"),
+            "must include key path: {out}"
+        );
+        assert!(
+            out.contains("-p"),
+            "must include -p flag for custom port: {out}"
+        );
+        assert!(out.contains("2222"), "must include port number: {out}");
+        assert!(
+            out.contains("deploy@myhost"),
+            "must include destination: {out}"
+        );
+    }
+
+    #[test]
+    fn test_verbose_password_auth_default_port() {
+        let conn = make_conn("password", None, 22, "myhost", "deploy");
+        let args = build_args(&conn);
+        let out = format_verbose(&args);
+        assert!(
+            out.starts_with("[yconn] Running: ssh"),
+            "must start with prefix: {out}"
+        );
+        assert!(
+            !out.contains("-i"),
+            "must not include -i flag for password auth: {out}"
+        );
+        assert!(
+            !out.contains("-p"),
+            "must not include port flag for default port: {out}"
+        );
+        assert!(
+            out.contains("deploy@myhost"),
+            "must include destination: {out}"
+        );
+    }
+
+    #[test]
+    fn test_verbose_password_auth_custom_port() {
+        let conn = make_conn("password", None, 2222, "myhost", "deploy");
+        let args = build_args(&conn);
+        let out = format_verbose(&args);
+        assert!(
+            out.starts_with("[yconn] Running: ssh"),
+            "must start with prefix: {out}"
+        );
+        assert!(
+            !out.contains("-i"),
+            "must not include -i flag for password auth: {out}"
+        );
+        assert!(
+            out.contains("-p"),
+            "must include -p flag for custom port: {out}"
+        );
+        assert!(out.contains("2222"), "must include port number: {out}");
+        assert!(
+            out.contains("deploy@myhost"),
+            "must include destination: {out}"
+        );
+    }
+
     // ── additional edge cases ─────────────────────────────────────────────────
 
     #[test]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -443,6 +443,17 @@ impl Renderer {
         }
     }
 
+    /// Print the full `ssh` command to stderr (for `--verbose`).
+    pub fn verbose_ssh_cmd(&self, args: &[String]) {
+        if let Some((first, rest)) = args.split_first() {
+            let mut line = format!("[yconn] Running: {}", first);
+            for arg in rest {
+                line.push_str(&format!(" \\\n         {}", arg));
+            }
+            eprintln!("{line}");
+        }
+    }
+
     /// Print a non-blocking warning to stderr.
     pub fn warn(&self, msg: &str) {
         eprintln!("warning: {msg}");
@@ -830,5 +841,24 @@ mod tests {
     #[test]
     fn test_verbose_docker_cmd_empty() {
         Renderer::new(false).verbose_docker_cmd(&[]);
+    }
+
+    // ── verbose_ssh_cmd tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_verbose_ssh_cmd_formats_args() {
+        // Just test that the function doesn't panic; output goes to stderr.
+        let renderer = Renderer::new(false);
+        renderer.verbose_ssh_cmd(&[
+            "ssh".into(),
+            "-i".into(),
+            "~/.ssh/id_rsa".into(),
+            "deploy@myhost".into(),
+        ]);
+    }
+
+    #[test]
+    fn test_verbose_ssh_cmd_empty() {
+        Renderer::new(false).verbose_ssh_cmd(&[]);
     }
 }


### PR DESCRIPTION
## Summary
- `yconn connect <name> --verbose` now prints `[yconn] Running: ssh ...` to stderr before replacing the process
- Uses the same multi-line `[yconn] Running: …` format as the existing Docker verbose path
- Added `verbose_ssh_cmd()` to the display renderer (mirrors `verbose_docker_cmd()`)
- No signature changes to `connect::exec()` — printing happens in `commands/connect.rs`

## Test plan
- [ ] `yconn connect prod --verbose` prints `[yconn] Running: ssh ...` to stderr before connecting
- [ ] `yconn connect prod` (no `--verbose`) prints nothing extra
- [ ] Unit tests cover all four SSH arg scenarios with verbose formatting
- [ ] All tests pass (`make test`)