### PR TITLE
feat(config): wildcard pattern matching for connection names with conflict detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +676,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
+ "wildmatch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2.182"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml = "0.9.34"
 thiserror = "2.0.18"
+wildmatch = "2"
 
 [profile.release]
 strip = true

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use crate::config::LoadedConfig;
 use crate::display::Renderer;
@@ -12,9 +12,7 @@ use crate::{connect, docker, security};
 // ─── Public command entry point ───────────────────────────────────────────────
 
 pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str, verbose: bool) -> Result<()> {
-    let conn = cfg
-        .find(name)
-        .ok_or_else(|| anyhow!("no connection named '{name}'"))?;
+    let conn = cfg.find_with_wildcard(name)?;
 
     // Security: validate the key file before trying to connect.
     // Expand a leading `~` so that the existence and permission checks operate
@@ -39,10 +37,10 @@ pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str, verbose: bool) -
 
     // Direct SSH path: replace the current process with ssh.
     if verbose {
-        let ssh_args = connect::build_args(conn);
+        let ssh_args = connect::build_args(&conn);
         renderer.verbose_ssh_cmd(&ssh_args);
     }
-    connect::exec(conn)
+    connect::exec(&conn)
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
@@ -91,9 +89,7 @@ mod tests {
         original_argv: &[String],
         in_container: bool,
     ) -> Result<ConnectPlan> {
-        let conn = cfg
-            .find(name)
-            .ok_or_else(|| anyhow!("no connection named '{name}'"))?;
+        let conn = cfg.find_with_wildcard(name)?;
 
         if let Some(ref docker_cfg) = cfg.docker {
             if !in_container {
@@ -102,7 +98,7 @@ mod tests {
             }
         }
 
-        Ok(ConnectPlan::Ssh(connect::build_args(conn)))
+        Ok(ConnectPlan::Ssh(connect::build_args(&conn)))
     }
 
     fn write_yaml(dir: &std::path::Path, name: &str, content: &str) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -163,6 +163,69 @@ impl LoadedConfig {
         self.connections.iter().find(|c| c.name == name)
     }
 
+    /// Find a connection by exact name or by wildcard pattern matching.
+    ///
+    /// Resolution order:
+    /// 1. Try an exact name lookup first — an exact match always wins.
+    /// 2. Scan all active (non-shadowed) connections whose names contain `*`
+    ///    or `?` for patterns that match `input` using glob-style matching.
+    /// 3. If exactly one pattern matches, return a clone of that connection
+    ///    with `host` replaced by `input` (the matched input IS the host).
+    /// 4. If two or more *different* patterns match, return an error naming
+    ///    each conflicting pattern and its source layer/file.
+    /// 5. Same-pattern shadowing across layers is handled by the existing
+    ///    priority merge — only the winning entry is in `self.connections`,
+    ///    so the same pattern name never appears twice here.
+    pub fn find_with_wildcard(&self, input: &str) -> anyhow::Result<Connection> {
+        use wildmatch::WildMatch;
+
+        // Step 1: exact name lookup.
+        if let Some(conn) = self.find(input) {
+            return Ok(conn.clone());
+        }
+
+        // Step 2: scan wildcard patterns in the active (non-shadowed) set.
+        let mut matches: Vec<&Connection> = Vec::new();
+        for conn in &self.connections {
+            let is_pattern = conn.name.contains('*') || conn.name.contains('?');
+            if is_pattern && WildMatch::new(&conn.name).matches(input) {
+                matches.push(conn);
+            }
+        }
+
+        match matches.len() {
+            0 => Err(anyhow::anyhow!("no connection named '{input}'")),
+            1 => {
+                let mut resolved = matches[0].clone();
+                // The matched input IS the host — override the pattern's host
+                // field with the literal input string.
+                resolved.host = input.to_string();
+                Ok(resolved)
+            }
+            _ => {
+                // Two or more *different* patterns matched — that is a conflict.
+                // (Same-pattern shadowing never reaches here because merge keeps
+                // only one winner per pattern name in self.connections.)
+                let conflict_list: Vec<String> = matches
+                    .iter()
+                    .map(|c| {
+                        format!(
+                            "  '{}' (layer: {}, file: {})",
+                            c.name,
+                            c.layer.label(),
+                            c.source_path.display()
+                        )
+                    })
+                    .collect();
+                Err(anyhow::anyhow!(
+                    "connection name '{}' matches multiple wildcard patterns:\n{}",
+                    input,
+                    conflict_list.join("\n")
+                ))
+            }
+        }
+    }
+
     /// Return the connections that should be shown by default.
     ///
     /// - If `group_filter` is `Some(name)`, return only connections whose
@@ -1375,5 +1438,151 @@ mod tests {
         let layers = &groups[0].layers;
         assert!(layers.contains(&"project".to_string()));
         assert!(layers.contains(&"user".to_string()));
+    }
+
+    // ── wildcard pattern matching ─────────────────────────────────────────────
+
+    /// A single wildcard pattern matches the input — connection proceeds with
+    /// the input as the host.
+    #[test]
+    fn test_wildcard_single_pattern_matches() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        // Pattern "web-*" should match "web-prod".
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Wildcard web\n",
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let conn = cfg.find_with_wildcard("web-prod").unwrap();
+        // The matched input must replace the host field.
+        assert_eq!(conn.host, "web-prod");
+        assert_eq!(conn.user, "deploy");
+        // The connection name stays as the pattern.
+        assert_eq!(conn.name, "web-*");
+    }
+
+    /// No exact name and no wildcard pattern matches — error returned.
+    #[test]
+    fn test_wildcard_no_match_returns_error() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Wildcard web\n",
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let err = cfg.find_with_wildcard("db-prod").unwrap_err();
+        assert!(
+            err.to_string().contains("db-prod"),
+            "error must name the input: {err}"
+        );
+    }
+
+    /// Two different wildcard patterns both match the same input — conflict error.
+    #[test]
+    fn test_wildcard_conflict_two_patterns_same_input() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        // Both "web-*" and "?eb-prod" match "web-prod".
+        // Note: bare `*` at the start of a YAML key is an anchor — quote it.
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            "connections:\n  web-*:\n    host: ph1\n    user: deploy\n    auth: password\n    description: Web wildcard\n  \"?eb-prod\":\n    host: ph2\n    user: admin\n    auth: password\n    description: Prefix wildcard\n",
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let err = cfg.find_with_wildcard("web-prod").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("web-*"),
+            "error must name pattern 'web-*': {msg}"
+        );
+        assert!(
+            msg.contains("?eb-prod"),
+            "error must name pattern '?eb-prod': {msg}"
+        );
+    }
+
+    /// Exact name always beats a matching wildcard pattern — no conflict check.
+    #[test]
+    fn test_wildcard_exact_name_beats_pattern() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        // "web-prod" is an exact entry AND "web-*" would also match.
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            "connections:\n  web-prod:\n    host: exact-host\n    user: exact-user\n    auth: password\n    description: Exact match\n  web-*:\n    host: wildcard-host\n    user: wildcard-user\n    auth: password\n    description: Wildcard\n",
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+        let conn = cfg.find_with_wildcard("web-prod").unwrap();
+        // Exact match wins — host is NOT replaced by the input.
+        assert_eq!(conn.host, "exact-host");
+        assert_eq!(conn.user, "exact-user");
+        assert_eq!(conn.name, "web-prod");
+    }
+
+    /// Same pattern in two layers is shadowing (priority merge), NOT a conflict.
+    /// Only the winning (higher-priority) entry should be in the active map, so
+    /// `find_with_wildcard` sees exactly one match and succeeds.
+    #[test]
+    fn test_wildcard_same_pattern_in_two_layers_is_shadowing_not_conflict() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        // Project layer defines "host-*" with user "project-user".
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "connections:\n  host-*:\n    host: proj-host\n    user: project-user\n    auth: password\n    description: Project wildcard\n",
+        );
+
+        let user = TempDir::new().unwrap();
+        // User layer also defines "host-*" — this is shadowed by the project layer.
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            "connections:\n  host-*:\n    host: user-host\n    user: user-user\n    auth: password\n    description: User wildcard\n",
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(root.path(), Some(user.path()), empty.path());
+        // Should succeed: only the project entry is in the active set.
+        let conn = cfg.find_with_wildcard("host-anything").unwrap();
+        assert_eq!(conn.host, "host-anything", "input must replace host");
+        assert_eq!(conn.user, "project-user", "project layer must win");
+    }
+
+    /// A `?` wildcard matches exactly one character.
+    #[test]
+    fn test_wildcard_question_mark_single_char() {
+        let cwd = TempDir::new().unwrap();
+        let user = TempDir::new().unwrap();
+        // "web-?" matches "web-1" but not "web-12".
+        write_yaml(
+            user.path(),
+            "connections.yaml",
+            "connections:\n  web-?:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Single char wildcard\n",
+        );
+        let empty = TempDir::new().unwrap();
+
+        let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
+
+        let conn = cfg.find_with_wildcard("web-1").unwrap();
+        assert_eq!(conn.host, "web-1");
+
+        let err = cfg.find_with_wildcard("web-12").unwrap_err();
+        assert!(err.to_string().contains("web-12"));
     }
 }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -789,3 +789,64 @@ fn project_layer_wins_over_user() {
         "expected user-host to be shadowed by project layer, got: {stdout}"
     );
 }
+
+// ─── Wildcard pattern matching ────────────────────────────────────────────────
+
+/// `yconn connect` with a wildcard pattern match: mock ssh receives
+/// `user@<input-hostname>` — the matched input is used as the host.
+#[test]
+fn wildcard_pattern_match_ssh_receives_input_as_host() {
+    let env = TestEnv::new();
+
+    // Pattern "web-*" in user config — any "web-<something>" input matches.
+    env.write_user_config(
+        "connections",
+        "connections:\n  web-*:\n    host: placeholder.internal\n    user: deploy\n    auth: password\n    description: Wildcard web servers\n",
+    );
+
+    // Connect using a concrete hostname that matches the pattern.
+    // Run inside container so Docker bootstrap is skipped.
+    let out = env.run_in_container(&["connect", "web-staging"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Mock ssh must receive "deploy@web-staging" — the input, NOT "placeholder.internal".
+    assert!(
+        stdout.contains("deploy@web-staging"),
+        "expected 'deploy@web-staging' in stdout (input used as host), got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("placeholder.internal"),
+        "expected placeholder host to NOT appear in stdout, got: {stdout}"
+    );
+}
+
+/// `yconn connect` with two conflicting wildcard patterns exits non-zero and
+/// names both patterns in stderr.
+#[test]
+fn wildcard_conflict_exits_nonzero_with_pattern_names_in_stderr() {
+    let env = TestEnv::new();
+
+    // Two patterns that both match "web-prod": "web-*" and "?eb-prod".
+    // Note: a bare `*` at the start of a YAML key is a YAML anchor — quote it.
+    env.write_user_config(
+        "connections",
+        "connections:\n  web-*:\n    host: ph1\n    user: deploy\n    auth: password\n    description: Web wildcard\n  \"?eb-prod\":\n    host: ph2\n    user: admin\n    auth: password\n    description: Prefix wildcard\n",
+    );
+
+    let out = env.run_in_container(&["connect", "web-prod"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for conflicting wildcard patterns, got 0"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("web-*"),
+        "expected pattern 'web-*' named in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("?eb-prod"),
+        "expected pattern '?eb-prod' named in stderr, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Connection names may now use glob-style wildcards (`*`, `?`) in YAML config
- `yconn connect host1` matches a pattern like `host*` — the input is used directly as the SSH hostname
- Exact-name entries always win before pattern matching is attempted
- Two different patterns matching the same input exits non-zero with a clear error naming each conflicting pattern, its layer, and source file
- Same-pattern shadowing across layers follows existing priority rules (not a conflict)
- Added `wildmatch = "2"` dependency (lightweight, no path-separator semantics)

## Test plan
- [ ] `yconn connect web-prod` matches pattern `web-*` and SSH receives `user@web-prod`
- [ ] Two patterns both matching the same input exits non-zero with both pattern names in stderr
- [ ] Exact name `web-prod` beats pattern `web-*` when both exist
- [ ] Same pattern in two layers uses the higher-priority layer (no conflict error)
- [ ] All 233 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)