### PR TITLE
docs: update configuration, man page, and examples for recent changes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,29 +17,34 @@ connection with the same name in a lower-priority layer.
 | 2 | user | `~/.config/yconn/connections.yaml` | Private to the local user |
 | 3 (lowest) | system | `/etc/yconn/connections.yaml` | Org-wide defaults, sysadmin-managed |
 
-A layer that has no file for the active group is silently skipped — not all layers need to define
-entries for every group.
+A layer that has no `connections.yaml` file is silently skipped.
 
 ### Project config discovery
 
 The project layer is found by walking upward from the current working directory (like git),
-checking each parent directory for a `.yconn/<group>.yaml`. The walk stops at `$HOME` or the
+checking each parent directory for a project config file. The walk stops at `$HOME` or the
 filesystem root. This means running from deep inside a project tree will find the config at the
 repo root.
 
-### Groups and filenames
+Three filename conventions are checked in each directory, in priority order:
 
-The active group determines which filename is loaded from each layer. The default group is
-`connections`, which maps to `connections.yaml`. Switching to a group named `work` causes
-`work.yaml` to be loaded from each layer instead.
+1. `.yconn/connections.yaml` — recommended; isolated in a subdirectory, git-trackable
+2. `.connections.yaml` — dotfile convention; stays in the project root
+3. `connections.yaml` — plain name; may conflict with other tools
 
-| Active group | File loaded from each layer |
-|---|---|
-| `connections` (default) | `connections.yaml` |
-| `work` | `work.yaml` |
-| `client-acme` | `client-acme.yaml` |
+The first match found in a directory wins; the walk then stops for that directory and moves up.
 
-See `yconn group --help` or [docs/examples.md](examples.md#multi-group-setup) for group commands.
+### Groups
+
+Groups are inline tags on individual connections. Each connection entry can carry an optional
+`group:` field. All connections live in `connections.yaml` regardless of their group.
+
+The active group (set with `yconn group use <name>`) acts as a filter: when a group is locked,
+`yconn list` shows only connections whose `group:` field matches. `yconn list --all` always
+shows all connections regardless of any lock.
+
+See `yconn group --help` or [docs/examples.md](examples.md#inline-group-field-usage) for group
+commands and examples.
 
 ---
 
@@ -67,6 +72,7 @@ connections:
     auth: key
     key: ~/.ssh/prod_deploy_key
     description: "Primary production web server"
+    group: work
     link: https://wiki.internal/servers/prod-web
 
   staging-db:
@@ -74,6 +80,7 @@ connections:
     user: dbadmin
     auth: password
     description: "Staging database server — use with caution"
+    group: work
     link: https://wiki.internal/servers/staging-db
 
   bastion:
@@ -91,16 +98,46 @@ connections:
 
 | Field | Required | Description |
 |---|---|---|
-| `host` | yes | Hostname or IP address |
+| `host` | yes | Hostname or IP address. May contain glob wildcards (`*`, `?`) — see [Wildcard patterns](#wildcard-patterns) below. |
 | `user` | yes | SSH login user |
 | `port` | no | SSH port — defaults to `22` |
 | `auth` | yes | `key` or `password` |
 | `key` | if `auth: key` | Path to private key file. When using Docker, the path is resolved inside the container. |
 | `description` | yes | Human-readable description of the connection |
+| `group` | no | Inline group tag. Used to filter connections with `yconn group use` or `yconn list --group`. |
 | `link` | no | URL for further documentation (wiki, runbook, etc.) |
 
-Each connection entry requires an explicit `host`. There is no pattern or glob matching — every
-host that should be reachable must have its own named entry.
+---
+
+## Wildcard patterns
+
+Connection names (YAML keys in the `connections:` map) can use glob-style wildcards:
+
+- `*` — matches any sequence of characters
+- `?` — matches any single character
+
+```yaml
+connections:
+  web-*:
+    host: ""   # ignored — the matched input IS the hostname
+    user: deploy
+    auth: key
+    key: ~/.ssh/web_key
+    description: "Any web server matching web-*"
+```
+
+When you run `yconn connect web-prod-01`, yconn matches the input against all known
+patterns. The matched input (`web-prod-01`) becomes the SSH hostname directly — there
+is no template substitution.
+
+**Lookup rules:**
+
+1. Exact name match wins immediately. No conflict check is performed.
+2. If no exact match, all wildcard patterns are tested against the input.
+3. Exactly one pattern must match. If two different patterns both match the same input,
+   yconn exits with a conflict error naming each pattern and its source file.
+4. Same-pattern names across layers follow normal priority rules (higher layer wins) and
+   do not trigger conflict detection.
 
 ---
 
@@ -220,7 +257,7 @@ active_group: work
 
 | Key | Description |
 |---|---|
-| `active_group` | The active group name. Omit or leave blank to use the default (`connections`). |
+| `active_group` | The active group name. Omit or leave blank to use the default (show all untagged and tagged connections). |
 
 The file is designed for forward compatibility — unknown keys are ignored rather than causing
 errors. An empty or absent file is valid and treated as all-defaults.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -236,20 +236,13 @@ RUN chmod 600 /keys/prod_deploy_key /keys/bastion_key
 
 ---
 
-## Multi-group setup
+## Inline group field usage
 
 **When to use:** You have logically separate sets of connections — for example `work` and
-`private` — and want to switch between them cleanly without mixing entries in one file.
+`private` — and want to switch between them cleanly. All connections live in one
+`connections.yaml` file; a `group:` field on each entry determines which set it belongs to.
 
-**File layout:**
-
-```
-~/.config/yconn/
-├── work.yaml
-└── private.yaml
-```
-
-**`~/.config/yconn/work.yaml`**
+**`~/.config/yconn/connections.yaml`**
 
 ```yaml
 version: 1
@@ -261,26 +254,22 @@ connections:
     auth: key
     key: ~/.ssh/work_key
     description: "Work production web server"
+    group: work
 
   work-db:
     host: 10.10.0.10
     user: dbadmin
     auth: password
     description: "Work database server"
-```
+    group: work
 
-**`~/.config/yconn/private.yaml`**
-
-```yaml
-version: 1
-
-connections:
   home-server:
     host: 192.168.1.100
     user: mans
     auth: key
     key: ~/.ssh/id_ed25519
     description: "Home server"
+    group: private
 
   vps:
     host: vps.example.com
@@ -288,18 +277,22 @@ connections:
     auth: key
     key: ~/.ssh/vps_key
     description: "Personal VPS"
+    group: private
 ```
 
 **Commands:**
 
 ```bash
-# List all available groups across all layers
+# List all available group values found across connections
 yconn group list
 
-# Switch to the work group
+# Show all connections (no group filter)
+yconn list
+
+# Switch to the work group — subsequent list/connect only shows work connections
 yconn group use work
 
-# List connections — now shows work.yaml entries
+# List only work connections
 yconn list
 
 # Connect to a work server
@@ -308,31 +301,176 @@ yconn connect work-web
 # Switch to the private group
 yconn group use private
 
-# List connections — now shows private.yaml entries
+# List only private connections
 yconn list
 
 # Connect to the home server
 yconn connect home-server
 
-# Check which group is currently active and which files are loaded
+# Show connections from a specific group without changing the active group
+yconn list --group work
+
+# Show all connections regardless of active group
+yconn list --all
+
+# Check which group is currently active
 yconn group current
 
-# Revert to the default group (connections.yaml)
+# Revert to no group filter (show all connections)
 yconn group clear
 ```
 
 **Notes:**
 
+- All connections live in `connections.yaml`. The `group:` field is just a tag — no
+  separate files per group.
 - The active group is stored in `~/.config/yconn/session.yml` and persists across
   terminal sessions until changed.
-- Each group is independent — switching groups changes which `.yaml` file is loaded
-  from every layer. A group with no file in a given layer simply skips that layer.
-- Groups can also be used at the project layer. For example, a repo with both
-  `.yconn/work.yaml` and a team member's user-level `~/.config/yconn/work.yaml`
-  will merge the two when the `work` group is active, with the project layer winning
-  on any name collision.
-- `yconn group use <name>` warns if no config file for that group exists in any layer,
-  but it still sets the group so you can follow up by creating the file with `yconn init`.
+- Connections without a `group:` field are always shown when no group filter is active.
+  When a group is locked, only tagged connections matching the group are shown.
+- `yconn list --all` always overrides any group filter and shows every connection.
+- `yconn group use <name>` warns if no connections with that group value exist in any
+  layer, but it still sets the group.
+
+---
+
+## Wildcard pattern usage
+
+**When to use:** You manage many similarly-named hosts (e.g. a fleet of web servers) and
+want a single connection entry to cover all of them, using the input hostname directly.
+
+**`.yconn/connections.yaml`**
+
+```yaml
+version: 1
+
+connections:
+  web-prod-*:
+    host: ""          # ignored — the matched input becomes the SSH hostname
+    user: deploy
+    auth: key
+    key: ~/.ssh/web_prod_key
+    description: "Production web fleet (web-prod-01, web-prod-02, ...)"
+
+  db-staging-?:
+    host: ""          # ignored — the matched input becomes the SSH hostname
+    user: dbadmin
+    auth: key
+    key: ~/.ssh/db_staging_key
+    description: "Staging database servers (db-staging-a, db-staging-b, ...)"
+
+  bastion:
+    host: bastion.example.com
+    user: ec2-user
+    port: 2222
+    auth: key
+    key: ~/.ssh/bastion_key
+    description: "Bastion host (exact match — takes priority over any pattern)"
+```
+
+**Commands:**
+
+```bash
+# Connect to web-prod-01 — matches web-prod-* pattern; input becomes the SSH hostname
+yconn connect web-prod-01
+
+# Connect to web-prod-07 — same pattern, different host
+yconn connect web-prod-07
+
+# Connect to db-staging-a — matches db-staging-? pattern
+yconn connect db-staging-a
+
+# Connect to bastion — exact match wins over any wildcard pattern
+yconn connect bastion
+
+# Show which pattern covers a given input (shows pattern name in source field)
+yconn show web-prod-01
+```
+
+**How wildcard matching works:**
+
+1. yconn first checks whether the input is an exact connection name. If found, it wins
+   immediately — no pattern check is done.
+2. All connection names are tested as glob patterns against the input. `*` matches any
+   sequence of characters; `?` matches any single character.
+3. The matched input string (`web-prod-01`) becomes the SSH hostname directly. The
+   `host:` field in the YAML entry is overridden by the matched input.
+4. If two different patterns both match the same input (e.g. `web-*` and `web-prod-*`
+   both match `web-prod-01`), yconn exits with a conflict error naming each pattern
+   and its source file. Resolve this by making your patterns non-overlapping.
+
+**Notes:**
+
+- The `host:` field in wildcard entries is overridden at connect time. You can leave it
+  blank or set it to a placeholder value — it will not be used for SSH.
+- Wildcard entries appear in `yconn list` with their pattern name (e.g. `web-prod-*`) in
+  the NAME column.
+- Same-pattern names across layers follow normal priority rules (higher layer wins) and
+  do not trigger conflict detection.
+
+---
+
+## Multi-location init
+
+**When to use:** You want to scaffold a `connections.yaml` at a specific location to match
+your project conventions — the default `.yconn/` subdirectory, a dotfile, or a plain file.
+
+The three `--location` values and their resulting paths:
+
+| `--location` value | Resulting file path | Notes |
+|---|---|---|
+| `yconn` (default) | `.yconn/connections.yaml` | Isolated in subdirectory; git-trackable; recommended |
+| `dotfile` | `.connections.yaml` | Hidden file in project root |
+| `plain` | `connections.yaml` | Plain file in project root; may conflict with other tools |
+
+**Commands:**
+
+```bash
+# Default — creates .yconn/connections.yaml
+yconn init
+
+# Dotfile convention — creates .connections.yaml in the current directory
+yconn init --location dotfile
+
+# Plain — creates connections.yaml in the current directory
+yconn init --location plain
+```
+
+**Resulting file trees:**
+
+```
+# yconn init (default)
+your-project/
+└── .yconn/
+    └── connections.yaml
+
+# yconn init --location dotfile
+your-project/
+└── .connections.yaml
+
+# yconn init --location plain
+your-project/
+└── connections.yaml
+```
+
+**Upward walk priority:**
+
+When yconn searches upward from the working directory, it checks all three conventions
+in each directory in this order:
+
+1. `.yconn/connections.yaml`
+2. `.connections.yaml`
+3. `connections.yaml`
+
+The first match in a given directory wins. The walk then moves up to the parent
+directory and checks again.
+
+**Notes:**
+
+- All three conventions are recognised by the upward walk — you can mix conventions
+  across different projects.
+- `yconn init` fails with a clear error if the target file already exists.
+- After running `yconn init`, edit the scaffolded file and run `yconn list` to verify.
 
 ---
 

--- a/docs/man/yconn.1.md
+++ b/docs/man/yconn.1.md
@@ -15,15 +15,22 @@ It uses a layered config system inspired by git and ssh, supports key-based and
 password-based auth, and is designed to be shareable in DevOps environments
 without ever exposing credentials.
 
-Connections are defined in YAML files and loaded from up to three layers:
+Connections are defined in `connections.yaml` files and loaded from up to three
+layers:
 
-- **project** — `.yconn/<group>.yaml`, discovered by walking up from the current
-  directory (like git); lives in version control
-- **user** — `~/.config/yconn/<group>.yaml`; private to the local user
-- **system** — `/etc/yconn/<group>.yaml`; org-wide defaults managed by sysadmins
+- **project** — `connections.yaml` (or `.connections.yaml` / `.yconn/connections.yaml`),
+  discovered by walking up from the current directory (like git); lives in version
+  control
+- **user** — `~/.config/yconn/connections.yaml`; private to the local user
+- **system** — `/etc/yconn/connections.yaml`; org-wide defaults managed by sysadmins
 
-Higher-priority layers win on name collision. A layer that has no file for the
-active group is silently skipped.
+Higher-priority layers win on name collision. A layer that has no `connections.yaml`
+is silently skipped.
+
+Connection names may contain glob wildcards (`*`, `?`). When a wildcard pattern is
+used, the matched input becomes the SSH hostname directly (the pattern IS the host
+template). Exact name matches always win over wildcard patterns. If two different
+patterns both match the same input, yconn exits with a conflict error.
 
 When a **docker** block is present in the project or system config, yconn
 re-invokes itself inside a container before doing anything else. This allows SSH
@@ -35,10 +42,13 @@ keys to be pre-baked into an image rather than distributed to developer machines
 : List all connections across all active config layers. Connections from
   higher-priority layers that shadow lower-priority ones are shown once.
   Use **--all** to also show shadowed entries.
+  Use **--group** *NAME* to filter to connections whose `group:` field equals *NAME*.
 
 **connect** *NAME*
 : Connect to the named host by invoking SSH. Replaces the current process so
-  terminal behavior (TTY, signals) works correctly.
+  terminal behavior (TTY, signals) works correctly. *NAME* is matched first as
+  an exact connection name, then against wildcard patterns. When a wildcard
+  pattern matches, the input string is used directly as the SSH hostname.
 
 **show** *NAME*
 : Print the resolved config for a connection. Credentials (key paths) are shown
@@ -46,42 +56,50 @@ keys to be pre-baked into an image rather than distributed to developer machines
 
 **add**
 : Interactive wizard that prompts for connection details and writes the entry to
-  a chosen layer.
+  a chosen layer. Use **--layer** to target a specific layer.
 
 **edit** *NAME*
 : Open the source config file that defines *NAME* in **$EDITOR**.
+  Use **--layer** to target a specific layer.
 
 **remove** *NAME*
 : Remove a connection. Prompts for which layer to target if the name exists in
-  more than one layer.
+  more than one layer. Use **--layer** to target a specific layer.
 
 **init**
-: Scaffold a `<group>.yaml` file in `.yconn/` in the current directory.
+: Scaffold a `connections.yaml` in the current directory. The **--location** flag
+  controls where the file is placed:
+
+  - **yconn** (default) — creates `.yconn/connections.yaml`; recommended for
+    git-tracked project configs
+  - **dotfile** — creates `.connections.yaml` in the current directory
+  - **plain** — creates `connections.yaml` in the current directory (may conflict
+    with other tools)
+
+  Fails with a clear error if the target file already exists.
 
 **config**
 : Show which config files are active, their paths, connection counts, and Docker
   bootstrap status.
 
 **group list**
-: Show all groups discovered across all layers and which layers contain them.
+: Show all unique group values found across connection entries in all loaded
+  layers, and which layers contain connections with each group tag.
 
 **group use** *NAME*
 : Set *NAME* as the active group. Writes to `~/.config/yconn/session.yml`.
-  A warning is emitted if no config file for that group exists in any layer, but
-  the group is still set.
+  A warning is emitted if no connections with that group value exist in any layer,
+  but the group is still set.
 
 **group clear**
-: Remove `active_group` from `session.yml`, reverting to the default group
-  (`connections`).
+: Remove `active_group` from `session.yml`, reverting to the default (no group
+  filter — all connections shown).
 
 **group current**
 : Print the active group name and the resolved config file paths for each layer,
   indicating which files were found.
 
 # OPTIONS
-
-**--layer** *system*|*user*|*project*
-: Target a specific config layer for **add**, **edit**, and **remove**.
 
 **--all**
 : Include shadowed entries in the output of **yconn list**.
@@ -90,14 +108,14 @@ keys to be pre-baked into an image rather than distributed to developer machines
 : Print config loading decisions, merge resolution, and the full Docker
   invocation command before it is executed.
 
-**--no-color**
-: Disable colored output. Automatically applied when stdout is not a terminal.
-
 **--help**
 : Print help and exit.
 
 **--version**
 : Print version and exit.
+
+The **--layer** *system*|*user*|*project* flag applies only to **add**, **edit**,
+and **remove** — it is a per-subcommand flag, not a global option.
 
 # CONFIGURATION
 
@@ -123,8 +141,24 @@ connections:
     auth: key         # "key" | "password"
     key: ~/.ssh/prod_deploy_key
     description: "Primary production web server"
+    group: work       # optional inline group tag
     link: https://wiki.internal/servers/prod-web
+
+  web-*:
+    host: ""          # ignored for wildcard entries — input IS the host
+    user: deploy
+    auth: key
+    key: ~/.ssh/web_key
+    description: "Any web server matching web-*"
 ```
+
+## Wildcard patterns
+
+Connection names may use `*` (any sequence) and `?` (any single character).
+When a wildcard pattern matches the input to **yconn connect**, the matched
+input string becomes the SSH hostname — no substitution occurs. Two different
+patterns matching the same input is a conflict and causes yconn to exit
+non-zero with a clear error.
 
 ## Session file
 
@@ -134,8 +168,8 @@ The active group is persisted to `~/.config/yconn/session.yml`:
 active_group: work
 ```
 
-An absent or empty session file is valid — the default group `connections` is
-used. Unknown keys are ignored for forward compatibility.
+An absent or empty session file is valid — no group filter is applied and all
+connections are shown. Unknown keys are ignored for forward compatibility.
 
 ## Docker bootstrap
 
@@ -158,10 +192,22 @@ List connections from all layers:
 yconn list
 ```
 
+Filter connections by group:
+
+```
+yconn list --group work
+```
+
 Connect to a host:
 
 ```
 yconn connect prod-web
+```
+
+Connect using a wildcard pattern (input becomes the SSH hostname):
+
+```
+yconn connect web-prod-01
 ```
 
 Show all details for a connection (including shadowed):
@@ -196,10 +242,12 @@ Show active config files and Docker status:
 yconn config
 ```
 
-Scaffold a project config for the current group:
+Scaffold a project config at different locations:
 
 ```
-yconn init
+yconn init                        # creates .yconn/connections.yaml (default)
+yconn init --location dotfile     # creates .connections.yaml
+yconn init --location plain       # creates connections.yaml
 ```
 
 # FILES
@@ -207,15 +255,22 @@ yconn init
 `~/.config/yconn/session.yml`
 : User session state — active group.
 
-`~/.config/yconn/<group>.yaml`
+`~/.config/yconn/connections.yaml`
 : User-level connection config. May reference local key paths.
 
-`/etc/yconn/<group>.yaml`
+`/etc/yconn/connections.yaml`
 : System-level connection config. Must not contain credentials.
 
-`.yconn/<group>.yaml`
-: Project-level connection config. Lives in version control. Must not contain
-  credentials.
+`.yconn/connections.yaml`
+: Project-level connection config (default location). Lives in version control.
+  Must not contain credentials.
+
+`.connections.yaml`
+: Project-level connection config (dotfile convention). Found by the upward walk.
+
+`connections.yaml`
+: Project-level connection config (plain convention). Found by the upward walk.
+  May conflict with other tools that use the same filename.
 
 # ENVIRONMENT
 


### PR DESCRIPTION
## Summary
- **docs/configuration.md**: replaced per-file group model with inline `group:` field explanation; added wildcard patterns section; updated project config discovery to cover all three filename conventions; added `group:` to connection fields table
- **docs/man/yconn.1.md**: documented `--location` flag on `init`; added wildcard pattern semantics; scoped `--layer` to add/edit/remove only; updated `group list` to describe connection field scanning; removed `--no-color`
- **docs/examples.md**: rewrote multi-group scenario to use inline `group:` field; added three new scenarios (inline groups, wildcard patterns, multi-location init)

## Test plan
- [ ] Docs accurately reflect inline `group:` field model (no references to work.yaml/private.yaml)
- [ ] `yconn init --location` documented with all three values and resulting paths
- [ ] Wildcard pattern semantics clearly explained (input IS the host, conflict detection)
- [ ] All 229 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)