### PR TITLE
feat(cli): collapse yconn ssh-config generate into yconn ssh-config

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -120,17 +120,8 @@ pub enum Commands {
         subcommand: GroupCommands,
     },
 
-    /// Generate or display an SSH config file from yconn connections
-    SshConfig {
-        #[command(subcommand)]
-        subcommand: SshConfigCommands,
-    },
-}
-
-#[derive(Debug, Subcommand)]
-pub enum SshConfigCommands {
     /// Write Host blocks to ~/.ssh/yconn-connections and update ~/.ssh/config
-    Generate {
+    SshConfig {
         /// Print generated config to stdout without writing any files
         #[arg(long)]
         dry_run: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod docker;
 mod group;
 mod security;
 
-use cli::{Cli, Commands, GroupCommands, SshConfigCommands};
+use cli::{Cli, Commands, GroupCommands};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -62,14 +62,12 @@ fn main() -> Result<()> {
             commands::remove::run(&cfg, &renderer, &name, layer)
         }
         Commands::Init { location } => commands::init::run(location),
-        Commands::SshConfig { subcommand } => match subcommand {
-            SshConfigCommands::Generate { dry_run } => {
-                let cfg = load_and_warn(&renderer, verbose)?;
-                let home = dirs::home_dir()
-                    .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
-                commands::ssh_config::run_generate(&cfg.connections, &renderer, dry_run, &home)
-            }
-        },
+        Commands::SshConfig { dry_run } => {
+            let cfg = load_and_warn(&renderer, verbose)?;
+            let home = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+            commands::ssh_config::run_generate(&cfg.connections, &renderer, dry_run, &home)
+        }
     }
 }
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -890,7 +890,7 @@ fn ssh_config_generate_writes_host_blocks_and_include() {
         "connections:\n  prod-web:\n    host: 10.0.1.50\n    user: deploy\n    auth: key\n    key: ~/.ssh/prod_key\n    description: Production web\n  staging-db:\n    host: staging.internal\n    user: dbadmin\n    port: 2222\n    auth: password\n    description: Staging database\n",
     );
 
-    let out = env.run(&["ssh-config", "generate"]);
+    let out = env.run(&["ssh-config"]);
     TestEnv::assert_ok(&out);
 
     // yconn-connections file must exist with correct Host blocks.
@@ -951,7 +951,7 @@ fn ssh_config_generate_dry_run_prints_to_stdout_no_files_written() {
         "connections:\n  myhost:\n    host: 192.168.1.1\n    user: admin\n    auth: password\n    description: My host\n",
     );
 
-    let out = env.run(&["ssh-config", "generate", "--dry-run"]);
+    let out = env.run(&["ssh-config", "--dry-run"]);
     TestEnv::assert_ok(&out);
 
     let stdout = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
## Summary
- Remove `SshConfigCommands` nested subcommand enum from `src/cli/mod.rs`
- Change `Commands::SshConfig` variant to hold `dry_run: bool` directly
- Simplify dispatch in `src/main.rs` to match `Commands::SshConfig { dry_run }` directly
- Update functional tests: `yconn ssh-config generate` → `yconn ssh-config`, `yconn ssh-config generate --dry-run` → `yconn ssh-config --dry-run`
- `yconn ssh-config generate` no longer exists — invoking it exits non-zero with clap "unexpected argument" error

## Test plan
- [ ] `make test` passes (257 tests: 232 unit + 25 functional)
- [ ] `yconn ssh-config` writes Host blocks and Include line
- [ ] `yconn ssh-config --dry-run` prints to stdout without writing files
- [ ] `yconn ssh-config generate` exits non-zero with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)