### PR TITLE
feat(cli): always print SSH command to stderr before exec in yconn connect

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -36,8 +36,9 @@ pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str, verbose: bool) -
     }
 
     // Direct SSH path: replace the current process with ssh.
+    let ssh_args = connect::build_args(&conn);
+    renderer.print_connecting(&ssh_args);
     if verbose {
-        let ssh_args = connect::build_args(&conn);
         renderer.verbose_ssh_cmd(&ssh_args);
     }
     connect::exec(&conn)
@@ -308,6 +309,93 @@ mod tests {
 
         let err = run(&cfg, &no_color(), "no-such-server", false).unwrap_err();
         assert!(err.to_string().contains("no-such-server"));
+    }
+
+    // ── print_connecting line format ──────────────────────────────────────────
+
+    /// Verify that the connecting line for a key-auth connection has the
+    /// expected single-line format: `[yconn] Connecting: ssh -i <key> user@host`.
+    #[test]
+    fn test_print_connecting_key_auth_format() {
+        // Use build_args directly — same path as run() uses.
+        use crate::config::{Connection, Layer};
+        use std::path::PathBuf;
+
+        let conn = Connection {
+            name: "srv".to_string(),
+            host: "myhost".to_string(),
+            user: "deploy".to_string(),
+            port: 22,
+            auth: "key".to_string(),
+            key: Some("~/.ssh/id_rsa".to_string()),
+            description: String::new(),
+            link: None,
+            group: None,
+            layer: Layer::User,
+            source_path: PathBuf::from("test.yaml"),
+            shadowed: false,
+        };
+        let args = crate::connect::build_args(&conn);
+        // Verify the connecting line would be: [yconn] Connecting: ssh -i ~/.ssh/id_rsa deploy@myhost
+        let line = format!("[yconn] Connecting: {}", args.join(" "));
+        assert!(
+            line.starts_with("[yconn] Connecting: ssh"),
+            "line must start with '[yconn] Connecting: ssh': {line}"
+        );
+        assert!(line.contains("-i"), "line must contain -i flag: {line}");
+        assert!(
+            line.contains("~/.ssh/id_rsa"),
+            "line must contain key path: {line}"
+        );
+        assert!(
+            line.contains("deploy@myhost"),
+            "line must contain destination: {line}"
+        );
+        assert!(
+            !line.contains('\n'),
+            "connecting line must be a single line: {line}"
+        );
+    }
+
+    /// Verify that the connecting line for a password-auth connection has the
+    /// expected single-line format: `[yconn] Connecting: ssh user@host`.
+    #[test]
+    fn test_print_connecting_password_auth_format() {
+        use crate::config::{Connection, Layer};
+        use std::path::PathBuf;
+
+        let conn = Connection {
+            name: "db".to_string(),
+            host: "db.internal".to_string(),
+            user: "dbadmin".to_string(),
+            port: 22,
+            auth: "password".to_string(),
+            key: None,
+            description: String::new(),
+            link: None,
+            group: None,
+            layer: Layer::User,
+            source_path: PathBuf::from("test.yaml"),
+            shadowed: false,
+        };
+        let args = crate::connect::build_args(&conn);
+        let line = format!("[yconn] Connecting: {}", args.join(" "));
+        assert!(
+            line.starts_with("[yconn] Connecting: ssh"),
+            "line must start with '[yconn] Connecting: ssh': {line}"
+        );
+        assert!(
+            !line.contains("-i"),
+            "line must not contain -i for password auth: {line}"
+        );
+        assert!(
+            line.contains("dbadmin@db.internal"),
+            "line must contain destination: {line}"
+        );
+        assert!(
+            !line.contains('\n'),
+            "connecting line must be a single line: {line}"
+        );
     }
 
     // ── expand_tilde ──────────────────────────────────────────────────────────

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -425,6 +425,17 @@ impl Renderer {
         }
     }
 
+    /// Print a single-line connecting notice to stderr, always emitted before SSH exec.
+    ///
+    /// Format: `[yconn] Connecting: ssh <arg1> <arg2> ...`
+    ///
+    /// This is intentionally different from `verbose_ssh_cmd` which uses a
+    /// multi-line backslash-continuation format — both coexist when `--verbose`
+    /// is also set.
+    pub fn print_connecting(&self, args: &[String]) {
+        eprintln!("[yconn] Connecting: {}", args.join(" "));
+    }
+
     /// Print a non-blocking warning to stderr.
     pub fn warn(&self, msg: &str) {
         eprintln!("warning: {msg}");

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -304,6 +304,68 @@ fn ssh_password_auth_custom_port() {
     );
 }
 
+// ─── Connecting line on stderr ────────────────────────────────────────────────
+
+#[test]
+fn connect_key_auth_prints_connecting_line_to_stderr() {
+    let env = TestEnv::new();
+    let key = env.write_key("id_rsa");
+    env.write_user_config(
+        "connections",
+        &conn_key("myconn", "myhost", "deploy", None, &key),
+    );
+
+    let out = env.run_in_container(&["connect", "myconn"]);
+    TestEnv::assert_ok(&out);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&format!("[yconn] Connecting: ssh -i {key} deploy@myhost")),
+        "expected '[yconn] Connecting: ssh -i {key} deploy@myhost' in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn connect_password_auth_prints_connecting_line_to_stderr() {
+    let env = TestEnv::new();
+    env.write_user_config(
+        "connections",
+        &conn_password("myconn", "db.internal", "dbadmin", None),
+    );
+
+    let out = env.run_in_container(&["connect", "myconn"]);
+    TestEnv::assert_ok(&out);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[yconn] Connecting: ssh dbadmin@db.internal"),
+        "expected '[yconn] Connecting: ssh dbadmin@db.internal' in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn connect_connecting_line_stdout_is_unaffected() {
+    // The connecting line goes to stderr — stdout (mock ssh output) must be unchanged.
+    let env = TestEnv::new();
+    env.write_user_config(
+        "connections",
+        &conn_password("myconn", "db.internal", "dbadmin", None),
+    );
+
+    let out = env.run_in_container(&["connect", "myconn"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ssh dbadmin@db.internal"),
+        "expected mock ssh output in stdout, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("[yconn] Connecting:"),
+        "connecting line must not appear in stdout, got: {stdout}"
+    );
+}
+
 // ─── Docker scenarios ─────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `Renderer::print_connecting(&[String])` method to `src/display/mod.rs` emitting `[yconn] Connecting: ssh <args...>` to stderr on a single line
- Hoist `connect::build_args(&conn)` out of the `if verbose` block in `src/commands/connect.rs` so args are available unconditionally
- Call `renderer.print_connecting(&ssh_args)` immediately before `connect::exec` — always, regardless of `--verbose`
- Docker bootstrap path unaffected (Docker exec happens before this code path)
- Add unit tests for `print_connecting` format (key-auth and password-auth)
- Add functional tests asserting `stderr` contains `[yconn] Connecting: ssh` with correct args

## Test plan
- [ ] `make test` passes (234 unit + 28 functional)
- [ ] `yconn connect <name>` prints `[yconn] Connecting: ssh ...` to stderr before connecting
- [ ] Line appears for both key-auth and password-auth connections
- [ ] `--verbose` multi-line Docker output is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)