### PR TITLE
fix(cli): remove yconn: prefix from SSH config comments

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -147,7 +147,7 @@
   - Reuse: src/cli/mod.rs:Commands (rename `User` variant to `Users`), src/cli/mod.rs:UserCommands (no structural change — variant name stays, only the CLI-facing command name changes via clap's `name` attribute or enum rename), src/main.rs:Commands::User match arm (rename to Commands::Users)
   - Risks: the Rust enum variant `Commands::User` and `UserCommands` type name must be kept or renamed consistently — if renamed to `Commands::Users` every match arm and import in main.rs must be updated; clap derives the CLI name from the variant name by default (lowercased), so renaming the variant to `Users` automatically changes the CLI token to `users` with no extra annotation needed; doc comments inside `src/commands/user.rs` that reference `yconn user` must be updated to `yconn users` to avoid misleading future readers; functional tests that invoke the binary with `["user", "show"]` etc. must be updated to `["users", "show"]`; no YAML config format changes — only the CLI surface changes
 
-- [ ] **Remove `yconn:` prefix from SSH config comments** [cli] S
+- [x] **Remove `yconn:` prefix from SSH config comments** [cli] S
   - Acceptance: `render_ssh_config` emits comments as `# description: …`, `# auth: …`, `# link: …`, and `# user: … (unresolved)` — the `yconn: ` substring no longer appears in any generated output; unit tests in `src/commands/ssh_config.rs` are updated so all `assert!(out.contains("# yconn: …"))` assertions become `assert!(out.contains("# …"))` and a negative assertion `assert!(!out.contains("# yconn:"))` is added to the link test; `make test` passes
   - Depends on: Rename `yconn user` command to `yconn users`
   - Modify: src/commands/ssh_config.rs

--- a/src/commands/ssh_config.rs
+++ b/src/commands/ssh_config.rs
@@ -60,10 +60,10 @@ pub fn render_ssh_config(connections: &[Connection], skip_user: bool) -> String 
         let ssh_hostname = translate_host_for_ssh(&conn.host);
 
         // Comment header with metadata.
-        out.push_str(&format!("# yconn: description: {}\n", conn.description));
-        out.push_str(&format!("# yconn: auth: {}\n", conn.auth));
+        out.push_str(&format!("# description: {}\n", conn.description));
+        out.push_str(&format!("# auth: {}\n", conn.auth));
         if let Some(link) = &conn.link {
-            out.push_str(&format!("# yconn: link: {link}\n"));
+            out.push_str(&format!("# link: {link}\n"));
         }
 
         out.push_str(&format!("Host {ssh_host}\n"));
@@ -72,7 +72,7 @@ pub fn render_ssh_config(connections: &[Connection], skip_user: bool) -> String 
             // If the user field still contains an unresolved template token,
             // emit a comment instead of an invalid SSH User directive.
             if conn.user.contains("${") {
-                out.push_str(&format!("# yconn: user: {} (unresolved)\n", conn.user));
+                out.push_str(&format!("# user: {} (unresolved)\n", conn.user));
             } else {
                 out.push_str(&format!("    User {}\n", conn.user));
             }
@@ -397,7 +397,8 @@ mod tests {
     fn test_link_field_appears_in_comment() {
         let conn = make_conn_with_link("srv", "https://wiki.example.com/srv");
         let out = render_ssh_config(&[conn], false);
-        assert!(out.contains("# yconn: link: https://wiki.example.com/srv"));
+        assert!(out.contains("# link: https://wiki.example.com/srv"));
+        assert!(!out.contains("# yconn:"));
     }
 
     // ── user field expansion ───────────────────────────────────────────────────
@@ -463,7 +464,7 @@ mod tests {
             "must not render as User line: {out}"
         );
         assert!(
-            out.contains("# yconn: user: ${user} (unresolved)"),
+            out.contains("# user: ${user} (unresolved)"),
             "must render as comment: {out}"
         );
     }


### PR DESCRIPTION
## Summary

- SSH config comments generated by `yconn ssh-config` no longer include the `yconn: ` prefix
- Before: `# yconn: description: Primary web server`
- After: `# description: Primary web server`
- Applies to all four comment types: `description`, `auth`, `link`, and `user: … (unresolved)`

## Changes

- `src/commands/ssh_config.rs`: stripped `yconn: ` from four format strings; updated unit test assertions to match new form; added negative assertion `assert!(!out.contains("# yconn:"))` to guard against regression

## Test plan

- [ ] `make test` passes (262 unit + 37 functional tests)
- [ ] `yconn ssh-config --dry-run` output contains `# description:` not `# yconn: description:`