### PR TITLE
feat(cli): add yconn show --dump flag to print fully merged config

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -155,7 +155,7 @@
   - Reuse: src/commands/ssh_config.rs:render_ssh_config (the four format strings on lines 63–75 are the only change sites)
   - Risks: none — pure string literal change with no logic impact; verify no external tooling parses the `# yconn:` prefix from generated files before stripping it
 
-- [ ] **Add `yconn show --dump` flag to print the fully merged config** [cli] S
+- [x] **Add `yconn show --dump` flag to print the fully merged config** [cli] S
   - Acceptance: (1) `yconn show --dump` (no connection name required) prints the fully merged `connections:` and `users:` maps to stdout as valid YAML after all layers have been loaded and merged — active entries only, no shadowed rows; (2) the output is machine-readable YAML with a top-level `connections:` key (each entry serialised with all its resolved fields) and a top-level `users:` key (each entry as a flat `key: value` map); (3) `yconn show --dump` and `yconn show <name>` are mutually exclusive — if both a name and `--dump` are supplied clap surfaces an error; (4) the `--dump` flag is only valid on the `show` subcommand, not global; (5) unit tests in `src/commands/show.rs` cover: dump with connections only, dump with users only, dump with both, dump with empty config; (6) a functional test in `tests/functional.rs` writes a project config with at least two connections and a users map, runs `yconn show --dump`, and asserts stdout is valid YAML containing all connection names and user keys; `make test` passes
   - Depends on: Remove `yconn:` prefix from SSH config comments
   - Modify: src/cli/mod.rs, src/main.rs, src/commands/show.rs, src/display/mod.rs, tests/functional.rs

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -73,8 +73,13 @@ pub enum Commands {
 
     /// Show the resolved config for a connection (no secrets printed)
     Show {
-        /// Name of the connection to inspect
-        name: String,
+        /// Name of the connection to inspect. Required unless --dump is set.
+        #[arg(required_unless_present = "dump", conflicts_with = "dump")]
+        name: Option<String>,
+        /// Print the fully merged connections: and users: maps as YAML.
+        /// Mutually exclusive with providing a connection name.
+        #[arg(long, conflicts_with = "name")]
+        dump: bool,
     },
 
     /// Interactive wizard to add a connection to a chosen layer

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,10 +1,68 @@
-// Handler for `yconn show <name>` — show the resolved config for a connection
-// without printing any secrets.
+// Handler for `yconn show <name>` and `yconn show --dump`.
 
-use anyhow::Result;
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
 
 use crate::config::LoadedConfig;
 use crate::display::{ConnectionDetail, Renderer};
+
+// ─── Dump serialisation types ─────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct DumpConn {
+    host: String,
+    user: String,
+    port: u16,
+    auth: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key: Option<String>,
+    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    link: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DumpOutput {
+    connections: HashMap<String, DumpConn>,
+    users: HashMap<String, String>,
+}
+
+/// Build the YAML string for `yconn show --dump`.
+fn build_dump_yaml(cfg: &LoadedConfig) -> Result<String> {
+    let mut connections = HashMap::new();
+    for conn in &cfg.connections {
+        connections.insert(
+            conn.name.clone(),
+            DumpConn {
+                host: conn.host.clone(),
+                user: conn.user.clone(),
+                port: conn.port,
+                auth: conn.auth.clone(),
+                key: conn.key.clone(),
+                description: conn.description.clone(),
+                link: conn.link.clone(),
+                group: conn.group.clone(),
+            },
+        );
+    }
+    let users: HashMap<String, String> = cfg
+        .users
+        .iter()
+        .map(|(k, v)| (k.clone(), v.value.clone()))
+        .collect();
+    let output = DumpOutput { connections, users };
+    serde_yaml::to_string(&output).context("failed to serialise config to YAML")
+}
+
+pub fn run_dump(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
+    let yaml = build_dump_yaml(cfg)?;
+    renderer.dump(&yaml);
+    Ok(())
+}
 
 pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str) -> Result<()> {
     let conn = cfg.find_with_wildcard(name)?;
@@ -51,6 +109,76 @@ mod tests {
         sys: &std::path::Path,
     ) -> config::LoadedConfig {
         config::load_impl(cwd, Some("connections"), false, user, sys).unwrap()
+    }
+
+    // ── dump unit tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_dump_with_connections_only() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Test server\n",
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+        let yaml = build_dump_yaml(&cfg).unwrap();
+        assert!(yaml.contains("connections:"));
+        assert!(yaml.contains("srv:"));
+        assert!(yaml.contains("10.0.0.1"));
+    }
+
+    #[test]
+    fn test_dump_with_users_only() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "users:\n  alice: al\n  bob: bobby\n",
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+        let yaml = build_dump_yaml(&cfg).unwrap();
+        assert!(yaml.contains("users:"));
+        assert!(yaml.contains("alice"));
+        assert!(yaml.contains("bob"));
+    }
+
+    #[test]
+    fn test_dump_with_connections_and_users() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "connections:\n  web:\n    host: 1.2.3.4\n    user: ${t1user}\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Web server\nusers:\n  t1user: alice\n",
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+        let yaml = build_dump_yaml(&cfg).unwrap();
+        assert!(yaml.contains("connections:"));
+        assert!(yaml.contains("users:"));
+        assert!(yaml.contains("web:"));
+        assert!(yaml.contains("t1user"));
+        // Raw unexpanded value in connections
+        assert!(yaml.contains("${t1user}"));
+    }
+
+    #[test]
+    fn test_dump_with_empty_config() {
+        let cwd = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        let cfg = load(cwd.path(), None, empty.path());
+        let yaml = build_dump_yaml(&cfg).unwrap();
+        // Valid YAML even with no data
+        assert!(yaml.contains("connections:"));
+        assert!(yaml.contains("users:"));
     }
 
     #[test]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -528,6 +528,11 @@ impl Renderer {
     pub fn error(&self, msg: &str) {
         eprintln!("error: {msg}");
     }
+
+    /// Print a pre-serialised YAML string to stdout (`yconn show --dump`).
+    pub fn dump(&self, yaml: &str) {
+        print!("{yaml}");
+    }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,17 @@ fn main() -> Result<()> {
             let cfg = load_and_warn(&renderer, verbose)?;
             commands::list::run(&cfg, &renderer, all, group.as_deref())
         }
-        Commands::Show { name } => {
+        Commands::Show { name, dump } => {
             let cfg = load_and_warn(&renderer, verbose)?;
-            commands::show::run(&cfg, &renderer, &name)
+            if dump {
+                commands::show::run_dump(&cfg, &renderer)
+            } else {
+                commands::show::run(
+                    &cfg,
+                    &renderer,
+                    &name.expect("name is required when --dump is not set"),
+                )
+            }
         }
         Commands::Config => {
             let cfg = load_and_warn(&renderer, verbose)?;

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1261,3 +1261,73 @@ fn user_show_prints_username_from_env_var() {
         "expected 'Username: bob' in output: {stdout}"
     );
 }
+
+// ─── show --dump ──────────────────────────────────────────────────────────────
+
+/// `yconn show --dump` outputs valid YAML containing all connection names and user keys.
+#[test]
+fn show_dump_outputs_merged_config_as_yaml() {
+    let env = TestEnv::new();
+    env.write_project_config(
+        "connections",
+        "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Production\n  staging:\n    host: 10.0.0.2\n    user: admin\n    auth: password\n    description: Staging\nusers:\n  t1user: alice\n  mybot: botuser\n",
+    );
+    let out = env.run(&["show", "--dump"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("connections:"), "missing connections: key");
+    assert!(stdout.contains("prod:"), "missing prod entry");
+    assert!(stdout.contains("staging:"), "missing staging entry");
+    assert!(stdout.contains("10.0.0.1"), "missing prod host");
+    assert!(stdout.contains("users:"), "missing users: key");
+    assert!(stdout.contains("t1user:"), "missing t1user key");
+    assert!(stdout.contains("mybot:"), "missing mybot key");
+}
+
+/// `yconn show --dump` with no config outputs empty-but-valid YAML.
+#[test]
+fn show_dump_empty_config_produces_valid_yaml() {
+    let env = TestEnv::new();
+    let out = env.run(&["show", "--dump"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("connections:"), "missing connections: key");
+    assert!(stdout.contains("users:"), "missing users: key");
+}
+
+/// `yconn show <name>` still works (name is still accepted).
+#[test]
+fn show_name_still_works_after_dump_flag_added() {
+    let env = TestEnv::new();
+    env.write_project_config(
+        "connections",
+        "connections:\n  web:\n    host: 1.2.3.4\n    user: ops\n    auth: password\n    description: Web\n",
+    );
+    let out = env.run(&["show", "web"]);
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Connection: web"));
+}
+
+/// `yconn show` with neither name nor --dump exits with an error.
+#[test]
+fn show_no_args_errors() {
+    let env = TestEnv::new();
+    let out = env.run(&["show"]);
+    assert!(!out.status.success(), "expected non-zero exit");
+}
+
+/// `yconn show <name> --dump` is rejected (mutually exclusive).
+#[test]
+fn show_name_and_dump_together_errors() {
+    let env = TestEnv::new();
+    env.write_project_config(
+        "connections",
+        "connections:\n  web:\n    host: 1.2.3.4\n    user: ops\n    auth: password\n    description: Web\n",
+    );
+    let out = env.run(&["show", "web", "--dump"]);
+    assert!(!out.status.success(), "expected non-zero exit");
+}


### PR DESCRIPTION
## Summary

- `yconn show --dump` prints the fully merged `connections:` and `users:` maps as valid YAML to stdout (active entries only, no shadowed rows)
- `yconn show <name>` continues to work unchanged
- `--dump` and a connection name are mutually exclusive — clap rejects both being supplied together
- `yconn show` with neither name nor `--dump` exits with a clap error

## Changes

- `src/cli/mod.rs` — `name` on `Show` made `Option<String>` with `required_unless_present = "dump"`; `dump: bool` added with `conflicts_with = "name"`
- `src/commands/show.rs` — `run_dump` + `build_dump_yaml` added using `serde::Serialize` dump-only structs; `serde(skip_serializing_if)` keeps output clean for optional fields
- `src/display/mod.rs` — `Renderer::dump` added to print pre-serialised YAML to stdout
- `src/main.rs` — `Show` match arm updated to dispatch to `run_dump` when `--dump` is set
- `tests/functional.rs` — 5 new functional tests covering: merged output, empty config, name still works, no-args error, name+dump conflict error

## Test plan

- [x] `make test` — all 42 tests pass
- [x] Unit tests: dump with connections only, users only, both, empty config
- [x] Functional tests: happy path YAML output, empty config, name still works, clap error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)