### PR TITLE
feat(cli): show user variable resolution table above connections in yconn list output

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,23 +1,132 @@
 // Handler for `yconn list` — list all connections across all layers.
 
+use std::collections::{HashMap, HashSet};
+
 use anyhow::Result;
 
 use crate::config::{Connection, LoadedConfig};
-use crate::display::{ConnectionRow, Renderer};
+use crate::display::{ConnectionRow, Renderer, UserRow};
 
 pub fn run(cfg: &LoadedConfig, renderer: &Renderer, all: bool, group: Option<&str>) -> Result<()> {
-    let rows: Vec<ConnectionRow> = if all {
-        cfg.all_connections.iter().map(conn_to_row).collect()
+    // Collect active connections for the table.
+    let active_connections: Vec<&Connection> = if all {
+        // When --all, we still scan only active (non-shadowed) connections
+        // for the Users table, but render all connections in the table.
+        cfg.connections.iter().collect()
     } else {
         let filter = cfg.effective_group_filter(all, group);
         cfg.filtered_connections(filter)
-            .iter()
-            .map(|c| conn_to_row(c))
-            .collect()
+    };
+
+    // Extract unique ${...} placeholder keys from the user field of active connections.
+    let user_rows = build_user_rows(cfg, &active_connections);
+
+    // Print Users table before connections if any placeholders were found.
+    if !user_rows.is_empty() {
+        println!("Users:");
+        renderer.user_list(&user_rows);
+        println!();
+    }
+
+    // Build and print connections table.
+    let rows: Vec<ConnectionRow> = if all {
+        cfg.all_connections.iter().map(conn_to_row).collect()
+    } else {
+        active_connections.iter().map(|c| conn_to_row(c)).collect()
     };
 
     renderer.list(&rows);
     Ok(())
+}
+
+/// Extract unique `${...}` placeholder keys from the `user` field of the given
+/// connections and build [`UserRow`] entries showing resolved values or
+/// `[unresolved]` with a fix hint.
+fn build_user_rows(cfg: &LoadedConfig, connections: &[&Connection]) -> Vec<UserRow> {
+    let mut seen = HashSet::new();
+    let mut keys_ordered: Vec<String> = Vec::new();
+
+    for conn in connections {
+        for key in extract_placeholder_keys(&conn.user) {
+            if seen.insert(key.clone()) {
+                keys_ordered.push(key);
+            }
+        }
+    }
+
+    let empty_overrides: HashMap<String, String> = HashMap::new();
+
+    keys_ordered
+        .into_iter()
+        .map(|key| {
+            // Try to resolve the key.
+            if key == "user" {
+                // ${user} resolves from $USER env var or users map.
+                let (expanded, warnings) =
+                    cfg.expand_user_field(&format!("${{{key}}}"), &empty_overrides);
+                if warnings.is_empty() && expanded != format!("${{{key}}}") {
+                    // Resolved — determine source.
+                    let source = if let Some(entry) = cfg.users.get(&key) {
+                        format!("{} ({})", entry.layer.label(), entry.source_path.display())
+                    } else {
+                        "env (environment variable $USER)".to_string()
+                    };
+                    UserRow {
+                        key,
+                        value: expanded,
+                        source,
+                        shadowed: false,
+                    }
+                } else {
+                    UserRow {
+                        key: key.clone(),
+                        value: "[unresolved]".to_string(),
+                        source: format!("-> yconn users add --user {}:VALUE", key),
+                        shadowed: false,
+                    }
+                }
+            } else if let Some(entry) = cfg.users.get(&key) {
+                UserRow {
+                    key,
+                    value: entry.value.clone(),
+                    source: format!("{} ({})", entry.layer.label(), entry.source_path.display()),
+                    shadowed: false,
+                }
+            } else {
+                UserRow {
+                    key: key.clone(),
+                    value: "[unresolved]".to_string(),
+                    source: format!("-> yconn users add --user {}:VALUE", key),
+                    shadowed: false,
+                }
+            }
+        })
+        .collect()
+}
+
+/// Extract all `${...}` placeholder key names from a string.
+///
+/// Returns keys in order of appearance. Duplicates within the same string
+/// are included — deduplication is the caller's responsibility.
+fn extract_placeholder_keys(s: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        if i + 1 < len && bytes[i] == b'$' && bytes[i + 1] == b'{' {
+            if let Some(close) = s[i + 2..].find('}') {
+                let key = &s[i + 2..i + 2 + close];
+                if !key.is_empty() {
+                    keys.push(key.to_string());
+                }
+                i += 2 + close + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    keys
 }
 
 fn conn_to_row(c: &Connection) -> ConnectionRow {
@@ -247,5 +356,197 @@ mod tests {
         assert_eq!(filtered.len(), 0);
 
         run(&cfg, &no_color(), false, Some("unknown")).unwrap();
+    }
+
+    // ─── extract_placeholder_keys tests ──────────────────────────────────────
+
+    #[test]
+    fn test_extract_single_placeholder() {
+        let keys = extract_placeholder_keys("${deploy_user}");
+        assert_eq!(keys, vec!["deploy_user"]);
+    }
+
+    #[test]
+    fn test_extract_multiple_placeholders() {
+        let keys = extract_placeholder_keys("${prefix}_${suffix}");
+        assert_eq!(keys, vec!["prefix", "suffix"]);
+    }
+
+    #[test]
+    fn test_extract_no_placeholders() {
+        let keys = extract_placeholder_keys("plain_user");
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn test_extract_user_placeholder() {
+        let keys = extract_placeholder_keys("${user}");
+        assert_eq!(keys, vec!["user"]);
+    }
+
+    // ─── Users table in yconn list tests ─────────────────────────────────────
+
+    fn conn_yaml_with_user(name: &str, host: &str, user: &str) -> String {
+        format!(
+            "connections:\n  {name}:\n    host: {host}\n    user: {user}\n    auth: key\n    description: desc\n"
+        )
+    }
+
+    fn conn_yaml_with_users_section(conns: &str, users: &str) -> String {
+        format!("{conns}\nusers:\n{users}")
+    }
+
+    #[test]
+    fn test_placeholder_resolved_shows_value_and_source() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        let yaml = conn_yaml_with_users_section(
+            &conn_yaml_with_user("srv", "10.0.0.1", "${deploy_user}"),
+            "  deploy_user: admin",
+        );
+        write_yaml(&yconn, "connections.yaml", &yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let active: Vec<&Connection> = cfg.connections.iter().collect();
+        let rows = build_user_rows(&cfg, &active);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "deploy_user");
+        assert_eq!(rows[0].value, "admin");
+        assert!(rows[0].source.contains("project"));
+        assert!(!rows[0].shadowed);
+    }
+
+    #[test]
+    fn test_placeholder_unresolved_shows_hint() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            &conn_yaml_with_user("srv", "10.0.0.1", "${missing_key}"),
+        );
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let active: Vec<&Connection> = cfg.connections.iter().collect();
+        let rows = build_user_rows(&cfg, &active);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "missing_key");
+        assert_eq!(rows[0].value, "[unresolved]");
+        assert!(rows[0]
+            .source
+            .contains("yconn users add --user missing_key:VALUE"));
+    }
+
+    #[test]
+    fn test_no_placeholders_produces_no_user_rows() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        write_yaml(&yconn, "connections.yaml", &simple_conn("srv", "10.0.0.1"));
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let active: Vec<&Connection> = cfg.connections.iter().collect();
+        let rows = build_user_rows(&cfg, &active);
+
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn test_mixed_resolved_and_unresolved_placeholders() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        // Two connections: one with a resolved placeholder, one with an unresolved one.
+        let yaml = conn_yaml_with_users_section(
+            &format!(
+                "connections:\n  srv1:\n    host: 10.0.0.1\n    user: ${{known_user}}\n    auth: key\n    description: desc\n  srv2:\n    host: 10.0.0.2\n    user: ${{unknown_user}}\n    auth: key\n    description: desc\n"
+            ),
+            "  known_user: admin",
+        );
+        write_yaml(&yconn, "connections.yaml", &yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let active: Vec<&Connection> = cfg.connections.iter().collect();
+        let rows = build_user_rows(&cfg, &active);
+
+        assert_eq!(rows.len(), 2);
+
+        // Find each row by key.
+        let known = rows.iter().find(|r| r.key == "known_user").unwrap();
+        let unknown = rows.iter().find(|r| r.key == "unknown_user").unwrap();
+
+        assert_eq!(known.value, "admin");
+        assert!(known.source.contains("project"));
+
+        assert_eq!(unknown.value, "[unresolved]");
+        assert!(unknown
+            .source
+            .contains("yconn users add --user unknown_user:VALUE"));
+    }
+
+    #[test]
+    fn test_duplicate_placeholder_deduplication() {
+        // The same ${deploy_user} in multiple connections should produce one row.
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        let yaml = conn_yaml_with_users_section(
+            &format!(
+                "connections:\n  srv1:\n    host: 10.0.0.1\n    user: ${{deploy_user}}\n    auth: key\n    description: desc\n  srv2:\n    host: 10.0.0.2\n    user: ${{deploy_user}}\n    auth: key\n    description: desc\n"
+            ),
+            "  deploy_user: admin",
+        );
+        write_yaml(&yconn, "connections.yaml", &yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let active: Vec<&Connection> = cfg.connections.iter().collect();
+        let rows = build_user_rows(&cfg, &active);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "deploy_user");
+        assert_eq!(rows[0].value, "admin");
+    }
+
+    #[test]
+    fn test_connections_table_preserves_raw_placeholder_syntax() {
+        // The USER column in the connections table should show the raw ${...} syntax.
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        let yaml = conn_yaml_with_users_section(
+            &conn_yaml_with_user("srv", "10.0.0.1", "${deploy_user}"),
+            "  deploy_user: admin",
+        );
+        write_yaml(&yconn, "connections.yaml", &yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        // The connection's user field should still contain the raw placeholder.
+        assert_eq!(cfg.connections[0].user, "${deploy_user}");
+
+        // The ConnectionRow should also preserve the raw syntax.
+        let row = conn_to_row(&cfg.connections[0]);
+        assert_eq!(row.user, "${deploy_user}");
     }
 }


### PR DESCRIPTION
## Summary
- Added a Users variable resolution table to `yconn list` output that appears before the connections table whenever `${...}` placeholders are found in active connections
- Each placeholder row shows resolved value and source (layer + path), or `[unresolved]` with a `-> yconn users add --user KEY:VALUE` fix hint
- Table is omitted when no placeholders exist
- Connections table USER column preserves raw `${variable}` syntax unchanged
- Added 8 unit tests covering resolved, unresolved, mixed, deduplication, and no-placeholder scenarios

## Test plan
- [x] `make test` passes (310 unit tests, 56 functional tests)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)