### PR TITLE
feat(cli): prompt for missing user variables during yconn install and ssh-config install

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,6 +5,7 @@
 // and copies all connections into the target layer file. New connections are
 // appended; existing ones prompt the user before overwriting.
 
+use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 
@@ -14,6 +15,7 @@ use crate::cli::LayerArg;
 use crate::config::{Layer, LoadedConfig};
 
 use super::add::{entry_exists, insert_connection, set_private_permissions};
+use super::user::write_user_entry;
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
@@ -109,6 +111,17 @@ pub(crate) fn run_impl(
         String::new()
     };
 
+    // Pre-pass: detect unresolved ${key} tokens in user fields and prompt.
+    let missing = find_unresolved_user_keys(&project_content, &target_content, &connection_names);
+    if !missing.is_empty() {
+        prompt_missing_user_keys(target_file, &missing, input, output)?;
+        // Re-read the target content since write_user_entry may have modified it.
+        if target_file.exists() {
+            target_content = std::fs::read_to_string(target_file)
+                .with_context(|| format!("failed to read {}", target_file.display()))?;
+        }
+    }
+
     let mut modified = false;
 
     for name in &connection_names {
@@ -172,6 +185,148 @@ pub(crate) fn run_impl(
         std::fs::write(target_file, &target_content)
             .with_context(|| format!("failed to write {}", target_file.display()))?;
         set_private_permissions(target_file)?;
+    }
+
+    Ok(())
+}
+
+// ─── Unresolved user variable helpers ─────────────────────────────────────────
+
+/// Extract all `${key}` tokens from a string, returning the key names.
+fn extract_all_template_keys(value: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find('}') {
+            let key = &after[..end];
+            if !key.is_empty() {
+                keys.push(key.to_string());
+            }
+            rest = &after[end + 1..];
+        } else {
+            break;
+        }
+    }
+    keys
+}
+
+/// Extract the user field value for a named connection from YAML content.
+///
+/// Looks for `    user: <value>` lines within the connection block (4-space
+/// indent under the 2-space connection name).
+fn extract_user_field(content: &str, conn_name: &str) -> Option<String> {
+    let header = format!("  {conn_name}:");
+    let mut in_block = false;
+
+    for line in content.lines() {
+        if line == header || line.starts_with(&format!("{header} ")) {
+            in_block = true;
+            continue;
+        }
+        if in_block {
+            if !line.starts_with("    ") {
+                break;
+            }
+            if let Some(rest) = line.strip_prefix("    user:") {
+                let val = rest.trim().trim_matches('"').trim_matches('\'');
+                return Some(val.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Extract existing user keys from the `users:` section of a YAML file.
+fn extract_existing_user_keys(content: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut in_users = false;
+
+    for line in content.lines() {
+        if line == "users:" || line.starts_with("users:") {
+            in_users = true;
+            continue;
+        }
+        if in_users {
+            if !line.is_empty() && !line.starts_with(' ') && !line.starts_with('\t') {
+                break;
+            }
+            if let Some(rest) = line.strip_prefix("  ") {
+                if let Some(key) = rest.split_once(':').map(|(k, _)| k) {
+                    if !key.is_empty() && !key.starts_with(' ') {
+                        keys.push(key.to_string());
+                    }
+                }
+            }
+        }
+    }
+    keys
+}
+
+/// Scan project connections for `${key}` tokens in user fields that are not
+/// resolved in the target file's `users:` section. Returns a map from
+/// unresolved key name to the list of connection names that reference it.
+fn find_unresolved_user_keys(
+    project_content: &str,
+    target_content: &str,
+    connection_names: &[String],
+) -> Vec<(String, Vec<String>)> {
+    let existing_keys = extract_existing_user_keys(target_content);
+
+    // key -> list of connection names
+    let mut unresolved: HashMap<String, Vec<String>> = HashMap::new();
+
+    for conn_name in connection_names {
+        if let Some(user_val) = extract_user_field(project_content, conn_name) {
+            for key in extract_all_template_keys(&user_val) {
+                if !existing_keys.contains(&key) {
+                    unresolved
+                        .entry(key.clone())
+                        .or_default()
+                        .push(conn_name.clone());
+                }
+            }
+        }
+    }
+
+    // Return in sorted order for deterministic output.
+    let mut result: Vec<(String, Vec<String>)> = unresolved.into_iter().collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
+}
+
+/// Prompt the user for each missing user variable and write the values to
+/// the target config file.
+fn prompt_missing_user_keys(
+    target_file: &Path,
+    missing: &[(String, Vec<String>)],
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<()> {
+    for (key, conn_names) in missing {
+        writeln!(
+            output,
+            "Missing user variable '${{{key}}}' used by: {}",
+            conn_names.join(", ")
+        )?;
+        write!(output, "  Value for '{key}': ")?;
+        output.flush()?;
+
+        let mut line = String::new();
+        input.read_line(&mut line)?;
+        let value = line.trim();
+
+        if value.is_empty() {
+            bail!("aborted: no value provided for user variable '{key}'");
+        }
+
+        write_user_entry(target_file, key, value)
+            .with_context(|| format!("failed to write user entry '{key}'"))?;
+        writeln!(
+            output,
+            "  Added user entry '{key}' to {}",
+            target_file.display()
+        )?;
     }
 
     Ok(())
@@ -487,5 +642,110 @@ mod tests {
         assert!(result.contains("host: new"), "new host not found");
         assert!(!result.contains("host: old"), "old host still present");
         assert!(result.contains("beta:"), "beta should still be present");
+    }
+
+    // ── unresolved user variable prompting ───────────────────────────────────
+
+    #[test]
+    fn test_unresolved_user_variable_triggers_prompt_and_writes_value() {
+        let dir = TempDir::new().unwrap();
+        let project_file = dir.path().join("project.yaml");
+        let target_file = dir.path().join("target.yaml");
+
+        // Project config with a ${t1user} template in the user field.
+        fs::write(
+            &project_file,
+            "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"test\"\n",
+        ).unwrap();
+
+        // Provide the prompted value followed by newline (no further stdin needed
+        // since there is only one new connection to append).
+        let (result, output) = run_with_stdin(&project_file, &target_file, "alice\n");
+        result.unwrap();
+
+        // The prompted value should be written to the target file's users: section.
+        let target = fs::read_to_string(&target_file).unwrap();
+        assert!(
+            target.contains("users:"),
+            "users: section must exist in target: {target}"
+        );
+        assert!(
+            target.contains("t1user:"),
+            "t1user entry must exist in target: {target}"
+        );
+        assert!(
+            target.contains("alice"),
+            "alice value must exist in target: {target}"
+        );
+
+        // Output should mention the missing variable and the connection.
+        assert!(
+            output.contains("Missing user variable '${t1user}' used by: alpha"),
+            "expected missing variable prompt in output, got: {output}"
+        );
+        assert!(
+            output.contains("Added user entry 't1user'"),
+            "expected confirmation in output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_all_keys_resolved_skips_prompting() {
+        let dir = TempDir::new().unwrap();
+        let project_file = dir.path().join("project.yaml");
+        let target_file = dir.path().join("target.yaml");
+
+        // Project config with a ${t1user} template.
+        fs::write(
+            &project_file,
+            "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"test\"\n",
+        ).unwrap();
+
+        // Pre-populate target with the t1user entry already resolved.
+        fs::write(&target_file, "version: 1\n\nusers:\n  t1user: \"alice\"\n").unwrap();
+
+        // No stdin data needed — no prompting should occur.
+        let (result, output) = run_with_stdin(&project_file, &target_file, "");
+        result.unwrap();
+
+        // No "Missing user variable" prompt should appear.
+        assert!(
+            !output.contains("Missing user variable"),
+            "should not prompt when key is already resolved, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_multiple_connections_same_missing_key_single_prompt() {
+        let dir = TempDir::new().unwrap();
+        let project_file = dir.path().join("project.yaml");
+        let target_file = dir.path().join("target.yaml");
+
+        // Two connections referencing the same ${t1user} key.
+        fs::write(
+            &project_file,
+            "version: 1\n\nconnections:\n  conn-a:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"a\"\n  conn-b:\n    host: 10.0.0.2\n    user: \"${t1user}\"\n    auth: password\n    description: \"b\"\n",
+        ).unwrap();
+
+        // Provide a single value — should only be prompted once.
+        let (result, output) = run_with_stdin(&project_file, &target_file, "alice\n");
+        result.unwrap();
+
+        // The prompt should list both connection names.
+        assert!(
+            output.contains("conn-a") && output.contains("conn-b"),
+            "prompt should list both connections, got: {output}"
+        );
+
+        // Only one "Missing user variable" line should appear.
+        let prompt_count = output.matches("Missing user variable").count();
+        assert_eq!(
+            prompt_count, 1,
+            "should prompt only once for the same key, got {prompt_count} prompts"
+        );
+
+        // Value should be written.
+        let target = fs::read_to_string(&target_file).unwrap();
+        assert!(target.contains("alice"), "prompted value must be written");
     }
 }

--- a/src/commands/ssh_config.rs
+++ b/src/commands/ssh_config.rs
@@ -3,13 +3,16 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::io::{self, BufRead, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
 use crate::config::{Connection, LoadedConfig};
 use crate::display::Renderer;
+
+use super::user::write_user_entry;
 
 // ─── Translation helpers ──────────────────────────────────────────────────────
 
@@ -297,7 +300,7 @@ fn merge_host_blocks(existing: Vec<HostBlock>, new_blocks: Vec<HostBlock>) -> St
 /// token and returns the key name so the caller can compose a fix command.
 ///
 /// Returns `None` if no `${...}` token is present.
-fn extract_unresolved_key(value: &str) -> Option<&str> {
+pub(crate) fn extract_unresolved_key(value: &str) -> Option<&str> {
     let start = value.find("${")?;
     let rest = &value[start + 2..];
     let end = rest.find('}')?;
@@ -336,6 +339,106 @@ pub fn remove_include_line(home: &Path) -> Result<bool> {
     Ok(true)
 }
 
+// ─── Unresolved user variable helpers ─────────────────────────────────────────
+
+/// Extract all `${key}` tokens from a string, returning the key names.
+fn extract_all_template_keys(value: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find('}') {
+            let key = &after[..end];
+            if !key.is_empty() {
+                keys.push(key.to_string());
+            }
+            rest = &after[end + 1..];
+        } else {
+            break;
+        }
+    }
+    keys
+}
+
+/// Scan all connections for `${key}` tokens in user fields that cannot be
+/// resolved by inline_overrides or cfg.users. Returns a vec of
+/// `(key_name, vec_of_connection_names)` sorted by key name.
+fn collect_unresolved_keys(
+    cfg: &LoadedConfig,
+    inline_overrides: &HashMap<String, String>,
+) -> Vec<(String, Vec<String>)> {
+    let mut unresolved: HashMap<String, Vec<String>> = HashMap::new();
+
+    for conn in &cfg.connections {
+        for key in extract_all_template_keys(&conn.user) {
+            // Check if the key can be resolved.
+            if inline_overrides.contains_key(&key) {
+                continue;
+            }
+            if cfg.users.contains_key(&key) {
+                continue;
+            }
+            // Special case: ${user} resolves from $USER env var.
+            if key == "user" && std::env::var("USER").is_ok() {
+                continue;
+            }
+            unresolved.entry(key).or_default().push(conn.name.clone());
+        }
+    }
+
+    let mut result: Vec<(String, Vec<String>)> = unresolved.into_iter().collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
+}
+
+/// Resolve the path to the user-layer connections.yaml file.
+fn resolve_user_layer_config_path() -> Result<PathBuf> {
+    let base = dirs::config_dir()
+        .ok_or_else(|| anyhow::anyhow!("cannot determine user config directory"))?;
+    Ok(base.join("yconn").join("connections.yaml"))
+}
+
+/// Prompt the user for each missing user variable, write to target file, and
+/// return the list of `(key, value)` pairs that were written.
+fn prompt_missing_keys(
+    target_file: &Path,
+    missing: &[(String, Vec<String>)],
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<Vec<(String, String)>> {
+    let mut prompted = Vec::new();
+
+    for (key, conn_names) in missing {
+        writeln!(
+            output,
+            "Missing user variable '${{{key}}}' used by: {}",
+            conn_names.join(", ")
+        )?;
+        write!(output, "  Value for '{key}': ")?;
+        output.flush()?;
+
+        let mut line = String::new();
+        input.read_line(&mut line)?;
+        let value = line.trim().to_string();
+
+        if value.is_empty() {
+            bail!("aborted: no value provided for user variable '{key}'");
+        }
+
+        write_user_entry(target_file, key, &value)
+            .with_context(|| format!("failed to write user entry '{key}'"))?;
+        writeln!(
+            output,
+            "  Added user entry '{key}' to {}",
+            target_file.display()
+        )?;
+
+        prompted.push((key.clone(), value));
+    }
+
+    Ok(prompted)
+}
+
 // ─── Command entry points ─────────────────────────────────────────────────────
 
 pub fn run_install(
@@ -346,10 +449,48 @@ pub fn run_install(
     inline_overrides: &HashMap<String, String>,
     skip_user: bool,
 ) -> Result<()> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    run_install_impl(
+        cfg,
+        renderer,
+        dry_run,
+        home,
+        inline_overrides,
+        skip_user,
+        &mut stdin.lock(),
+        &mut stdout.lock(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_install_impl(
+    cfg: &LoadedConfig,
+    renderer: &Renderer,
+    dry_run: bool,
+    home: &Path,
+    inline_overrides: &HashMap<String, String>,
+    skip_user: bool,
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<()> {
+    // Pre-pass: detect unresolved ${key} tokens and prompt for missing values.
+    let mut effective_overrides = inline_overrides.clone();
+    let missing = collect_unresolved_keys(cfg, &effective_overrides);
+    if !missing.is_empty() {
+        let user_layer_file = resolve_user_layer_config_path()?;
+        let prompted = prompt_missing_keys(&user_layer_file, &missing, input, output)?;
+        // Add prompted values to effective_overrides so expand_user_field
+        // resolves them without needing to reload config.
+        for (key, value) in prompted {
+            effective_overrides.insert(key, value);
+        }
+    }
+
     // Expand ${<key>} templates in the user field of each connection.
     let mut connections: Vec<Connection> = cfg.connections.clone();
     for conn in &mut connections {
-        let (expanded, warnings) = cfg.expand_user_field(&conn.user, inline_overrides);
+        let (expanded, warnings) = cfg.expand_user_field(&conn.user, &effective_overrides);
         for w in &warnings {
             // Extract the unresolved key from the expanded user field so we can
             // suggest the fix command.  The expanded value still contains the
@@ -1101,6 +1242,126 @@ mod tests {
         assert!(
             !out.contains("User "),
             "User line must be absent with skip_user=true"
+        );
+    }
+
+    // ── unresolved user variable prompting in run_install_impl ────────────────
+
+    /// Helper: build a LoadedConfig from user-layer YAML.
+    fn load_cfg(yaml: &str) -> (crate::config::LoadedConfig, tempfile::TempDir) {
+        use crate::config;
+        use tempfile::TempDir;
+
+        let user_dir = TempDir::new().unwrap();
+        let cwd = TempDir::new().unwrap();
+        let sys = TempDir::new().unwrap();
+        fs::write(user_dir.path().join("connections.yaml"), yaml).unwrap();
+
+        let cfg = config::load_impl(
+            cwd.path(),
+            Some("connections"),
+            false,
+            Some(user_dir.path()),
+            sys.path(),
+        )
+        .unwrap();
+
+        (cfg, user_dir)
+    }
+
+    /// `run_install_impl` with an unresolved `${t1user}` template halts
+    /// and prompts. After the user supplies a value, the Host block uses
+    /// the resolved value.
+    #[test]
+    fn test_run_install_impl_unresolved_key_prompts_and_resolves() {
+        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth: password\n    description: test\n";
+        let (cfg, _user_dir) = load_cfg(yaml);
+
+        let home = tempfile::TempDir::new().unwrap();
+        let ssh_dir = home.path().join(".ssh");
+        fs::create_dir_all(&ssh_dir).unwrap();
+
+        let renderer = crate::display::Renderer::new(false);
+
+        let mut input = "alice\n".as_bytes();
+        let mut output = Vec::<u8>::new();
+
+        // We need XDG_CONFIG_HOME set for resolve_user_layer_config_path.
+        // But the function uses dirs::config_dir() which reads XDG_CONFIG_HOME.
+        // In test context, we set it temporarily.
+        let xdg_dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("XDG_CONFIG_HOME", xdg_dir.path());
+
+        let result = super::run_install_impl(
+            &cfg,
+            &renderer,
+            false,
+            home.path(),
+            &HashMap::new(),
+            false,
+            &mut input,
+            &mut output,
+        );
+        result.unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(
+            output_str.contains("Missing user variable '${t1user}' used by: srv"),
+            "expected prompt for missing variable, got: {output_str}"
+        );
+        assert!(
+            output_str.contains("Added user entry 't1user'"),
+            "expected confirmation, got: {output_str}"
+        );
+
+        // Check that the Host block was written with the resolved value.
+        let host_blocks =
+            fs::read_to_string(home.path().join(".ssh").join("yconn-connections")).unwrap();
+        assert!(
+            host_blocks.contains("User alice"),
+            "expected 'User alice' in Host block, got: {host_blocks}"
+        );
+    }
+
+    /// `run_install_impl` with all keys already resolved produces no prompts.
+    #[test]
+    fn test_run_install_impl_resolved_keys_no_prompt() {
+        let yaml = "users:\n  t1user: \"bob\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth: password\n    description: test\n";
+        let (cfg, _user_dir) = load_cfg(yaml);
+
+        let home = tempfile::TempDir::new().unwrap();
+        let ssh_dir = home.path().join(".ssh");
+        fs::create_dir_all(&ssh_dir).unwrap();
+
+        let renderer = crate::display::Renderer::new(false);
+
+        let mut input = "".as_bytes();
+        let mut output = Vec::<u8>::new();
+
+        let result = super::run_install_impl(
+            &cfg,
+            &renderer,
+            false,
+            home.path(),
+            &HashMap::new(),
+            false,
+            &mut input,
+            &mut output,
+        );
+        result.unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(
+            !output_str.contains("Missing user variable"),
+            "should not prompt when all keys are resolved, got: {output_str}"
+        );
+
+        // Check that the Host block uses the resolved value.
+        let host_blocks =
+            fs::read_to_string(home.path().join(".ssh").join("yconn-connections")).unwrap();
+        assert!(
+            host_blocks.contains("User bob"),
+            "expected 'User bob' in Host block, got: {host_blocks}"
         );
     }
 }

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -140,7 +140,7 @@ fn layer_arg_to_layer(layer: Option<LayerArg>) -> Layer {
     }
 }
 
-fn layer_path(layer: Layer) -> Result<PathBuf> {
+pub(crate) fn layer_path(layer: Layer) -> Result<PathBuf> {
     match layer {
         Layer::System => Ok(PathBuf::from("/etc/yconn")),
         Layer::User => {
@@ -222,7 +222,7 @@ fn resolve_edit_path(cfg: &LoadedConfig, key: &str, layer: Option<LayerArg>) -> 
 // ─── YAML write helper ────────────────────────────────────────────────────────
 
 /// Append (or create) a `users:` entry in the target YAML file.
-fn write_user_entry(target: &Path, key: &str, value: &str) -> Result<()> {
+pub(crate) fn write_user_entry(target: &Path, key: &str, value: &str) -> Result<()> {
     if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1120,11 +1120,11 @@ fn ssh_config_skip_user_omits_user_lines() {
     );
 }
 
-/// `yconn ssh-config install` with an unresolved `${t1user}` template emits a
-/// warning on stderr that contains both "unresolved" and the fix command
-/// `yconn users add --user t1user:<value>`.
+/// `yconn ssh-config install` with an unresolved `${t1user}` template prompts
+/// for the missing value and, once provided, writes the Host block with the
+/// resolved user and persists the value to the user-layer config.
 #[test]
-fn ssh_config_unresolved_user_template_emits_fix_command_in_warning() {
+fn ssh_config_unresolved_user_template_prompts_and_resolves() {
     let env = TestEnv::new();
 
     env.write_user_config(
@@ -1132,17 +1132,34 @@ fn ssh_config_unresolved_user_template_emits_fix_command_in_warning() {
         "connections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth: password\n    description: test\n",
     );
 
-    // Run without --dry-run; the warning should appear on stderr regardless.
-    let out = env.run(&["ssh-config", "install"]);
+    // Provide the value via stdin.
+    let out = env.run_with_stdin(&["ssh-config", "install"], "alice\n");
+    TestEnv::assert_ok(&out);
 
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stderr.contains("unresolved"),
-        "expected 'unresolved' in stderr, got: {stderr}"
+        stdout.contains("Missing user variable '${t1user}' used by: srv"),
+        "expected prompt for missing variable in stdout, got: {stdout}"
     );
     assert!(
-        stderr.contains("yconn users add --user t1user:<value>"),
-        "expected fix command in stderr, got: {stderr}"
+        stdout.contains("Added user entry 't1user'"),
+        "expected confirmation in stdout, got: {stdout}"
+    );
+
+    // Verify the Host block was written with the resolved value.
+    let host_blocks =
+        fs::read_to_string(env.home.path().join(".ssh").join("yconn-connections")).unwrap();
+    assert!(
+        host_blocks.contains("User alice"),
+        "expected 'User alice' in Host block, got: {host_blocks}"
+    );
+
+    // Verify the value was persisted to the user-layer config.
+    let user_config =
+        fs::read_to_string(env.xdg_config.path().join("yconn").join("connections.yaml")).unwrap();
+    assert!(
+        user_config.contains("t1user:") && user_config.contains("alice"),
+        "expected t1user entry in user config, got: {user_config}"
     );
 }
 
@@ -1878,5 +1895,86 @@ fn install_updates_existing_with_y_and_appends_new() {
     assert!(
         stdout.contains("Writing: connection beta ->"),
         "expected 'Writing: connection beta ->' in stdout for beta, got: {stdout}"
+    );
+}
+
+// ─── yconn install — missing user variable prompting ─────────────────────────
+
+/// `yconn install` with a project config containing `${t1user}` prompts for
+/// the missing value, writes it to the user-layer config, and completes the
+/// install.
+#[test]
+fn install_missing_user_variable_prompts_and_writes_value() {
+    let env = TestEnv::new();
+
+    env.write_project_config(
+        "connections",
+        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"Alpha server\"\n",
+    );
+
+    // Provide the value for the missing user variable via stdin.
+    let out = env.run_with_stdin(&["install"], "alice\n");
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Missing user variable '${t1user}' used by: alpha"),
+        "expected prompt for missing variable in stdout, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Added user entry 't1user'"),
+        "expected confirmation in stdout, got: {stdout}"
+    );
+
+    // Verify the connection was installed.
+    let user_config = env.xdg_config.path().join("yconn").join("connections.yaml");
+    assert!(user_config.exists(), "user config must be created");
+    let content = fs::read_to_string(&user_config).unwrap();
+    assert!(content.contains("alpha:"), "alpha not found in user config");
+    assert!(
+        content.contains("t1user:") && content.contains("alice"),
+        "t1user entry must be written to user config: {content}"
+    );
+}
+
+/// `yconn ssh-config install` with a missing user variable prompts and writes
+/// the value, then generates correct Host blocks with the resolved user.
+#[test]
+fn ssh_config_install_missing_user_variable_prompts_and_generates_correct_host_blocks() {
+    let env = TestEnv::new();
+
+    env.write_user_config(
+        "connections",
+        "connections:\n  conn-a:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: A\n  conn-b:\n    host: 10.0.0.2\n    user: \"${t1user}\"\n    auth: password\n    description: B\n",
+    );
+
+    // Both connections share the same ${t1user} key — should prompt only once.
+    let out = env.run_with_stdin(&["ssh-config", "install"], "bob\n");
+    TestEnv::assert_ok(&out);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Only one prompt for the shared key.
+    let prompt_count = stdout.matches("Missing user variable").count();
+    assert_eq!(
+        prompt_count, 1,
+        "should prompt only once for the same key, got {prompt_count}"
+    );
+    // Both connections should be listed.
+    assert!(
+        stdout.contains("conn-a") && stdout.contains("conn-b"),
+        "prompt should list both connections, got: {stdout}"
+    );
+
+    // Verify Host blocks have the resolved user.
+    let host_blocks =
+        fs::read_to_string(env.home.path().join(".ssh").join("yconn-connections")).unwrap();
+    assert!(
+        host_blocks.contains("User bob"),
+        "expected 'User bob' in Host blocks, got: {host_blocks}"
+    );
+    // No unresolved token should remain.
+    assert!(
+        !host_blocks.contains("${t1user}"),
+        "unresolved token should not appear in Host blocks: {host_blocks}"
     );
 }


### PR DESCRIPTION
## Summary
- `yconn install` and `yconn ssh-config install` now detect unresolved `${key}` tokens in connection user fields before writing any files
- When unresolved keys are found, commands halt and print a grouped prompt listing each missing key and the connections that reference it
- User-provided values are persisted to the user-layer config via `write_user_entry`
- When all variables are already resolved, commands behave identically to before
- Made `write_user_entry` and `layer_path` in `user.rs` pub(crate) for reuse

## Test plan
- [x] `make test` passes — unit tests cover: unresolved key triggers prompt, resolved keys skip prompting, multiple connections with same missing key produce single prompt
- [x] Functional tests cover both `yconn install` and `yconn ssh-config install` with missing user variables
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)