### PR TITLE
feat(core): restructure auth from string field into structured node with type, key, and cmd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,15 +114,18 @@ connections:
     host: 10.0.1.50
     user: deploy
     port: 22                          # optional, defaults to 22
-    auth: key                         # "key" or "password"
-    key: ~/.ssh/prod_deploy_key       # required when auth is "key"; inside docker, path is inside container
+    auth:
+      type: key                       # "key" or "password"
+      key: ~/.ssh/prod_deploy_key     # required when type is "key"; inside docker, path is inside container
+      cmd: "vault read ssh/key"       # optional shell command (parsed and stored only)
     description: "Primary production web server"
     link: https://wiki.internal/servers/prod-web   # optional
 
   staging-db:
     host: staging.internal
     user: dbadmin
-    auth: password                    # SSH will prompt at runtime; password never stored
+    auth:
+      type: password                  # SSH will prompt at runtime; password never stored
     description: "Staging database server — use with caution"
     link: https://wiki.internal/servers/staging-db
 
@@ -130,8 +133,9 @@ connections:
     host: bastion.example.com
     user: ec2-user
     port: 2222
-    auth: key
-    key: ~/.ssh/bastion_key
+    auth:
+      type: key
+      key: ~/.ssh/bastion_key
     description: "Bastion host — jump point for internal network"
 ```
 
@@ -162,8 +166,10 @@ execution to an arbitrary Docker image.
 | `host` | yes | Hostname or IP address |
 | `user` | yes | SSH login user |
 | `port` | no | SSH port, defaults to 22 |
-| `auth` | yes | `key` or `password` |
-| `key` | if auth=key | Path to private key file (resolved inside container when using Docker) |
+| `auth` | yes | YAML mapping with `type` (required), `key` (required when type=key), and `cmd` (optional) |
+| `auth.type` | yes | `key` or `password` |
+| `auth.key` | if type=key | Path to private key file (resolved inside container when using Docker) |
+| `auth.cmd` | no | Shell command string (parsed and stored only — not executed in v1) |
 | `description` | yes | Human-readable description of the connection |
 | `link` | no | URL for further documentation (wiki, runbook, etc.) |
 
@@ -389,7 +395,7 @@ active group resolution to the `group` module to determine which filename to loa
 which groups have config files, used by `yconn group list`.
 
 **connect** — Takes a resolved connection entry and builds the SSH invocation arguments. Executes
-SSH by replacing the current process so terminal behavior works correctly. For `auth: password`,
+SSH by replacing the current process so terminal behavior works correctly. For `Auth::Password`,
 the native SSH password prompt is used — no password is ever passed programmatically. Key
 passphrases are handled entirely by the user's `ssh-agent`.
 
@@ -442,10 +448,10 @@ argument construction is exercised.
 
 | Scenario | Config | Expected SSH args |
 |---|---|---|
-| Key auth, default port | `auth: key`, `key: ~/.ssh/id_rsa` | `ssh -i ~/.ssh/id_rsa user@host` |
-| Key auth, custom port | `auth: key`, `port: 2222` | `ssh -i ~/.ssh/id_rsa -p 2222 user@host` |
-| Password auth | `auth: password` | `ssh user@host` (no `-i`, no password arg) |
-| Password auth, custom port | `auth: password`, `port: 2222` | `ssh -p 2222 user@host` |
+| Key auth, default port | `auth: { type: key, key: ~/.ssh/id_rsa }` | `ssh -i ~/.ssh/id_rsa user@host` |
+| Key auth, custom port | `auth: { type: key, key: ~/.ssh/id_rsa }`, `port: 2222` | `ssh -i ~/.ssh/id_rsa -p 2222 user@host` |
+| Password auth | `auth: { type: password }` | `ssh user@host` (no `-i`, no password arg) |
+| Password auth, custom port | `auth: { type: password }`, `port: 2222` | `ssh -p 2222 user@host` |
 
 **Group scenarios:**
 

--- a/config/connections.yaml
+++ b/config/connections.yaml
@@ -14,15 +14,17 @@ connections:
     host: 10.0.1.50
     user: deploy
     port: 22
-    auth: key
-    key: ~/.ssh/prod_deploy_key
+    auth:
+      type: key
+      key: ~/.ssh/prod_deploy_key
     description: "Primary production web server"
     link: https://wiki.internal/servers/prod-web
 
   staging-db:
     host: staging.internal
     user: dbadmin
-    auth: password
+    auth:
+      type: password
     description: "Staging database server — use with caution"
     link: https://wiki.internal/servers/staging-db
 
@@ -30,6 +32,7 @@ connections:
     host: bastion.example.com
     user: ec2-user
     port: 2222
-    auth: key
-    key: ~/.ssh/bastion_key
+    auth:
+      type: key
+      key: ~/.ssh/bastion_key
     description: "Bastion host — jump point for internal network"

--- a/docs/man/yconn.1.md
+++ b/docs/man/yconn.1.md
@@ -213,8 +213,9 @@ connections:
     host: 10.0.1.50
     user: ${testuser}   # expands to "testusername" at connect time
     port: 22          # optional, defaults to 22
-    auth: key         # "key" | "password"
-    key: ~/.ssh/prod_deploy_key
+    auth:
+      type: key       # "key" | "password"
+      key: ~/.ssh/prod_deploy_key
     description: "Primary production web server"
     group: work       # optional inline group tag
     link: https://wiki.internal/servers/prod-web
@@ -222,15 +223,17 @@ connections:
   web-*:
     host: "${name}.corp.com"   # ${name} is replaced with the matched input
     user: deploy
-    auth: key
-    key: ~/.ssh/web_key
+    auth:
+      type: key
+      key: ~/.ssh/web_key
     description: "Any web server matching web-*"
 
   "app[1..20]":
     host: "${name}.internal"   # app5 → app5.internal
     user: ops
-    auth: key
-    key: ~/.ssh/ops_key
+    auth:
+      type: key
+      key: ~/.ssh/ops_key
     description: "App servers 1 through 20"
 ```
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -182,9 +182,11 @@ pub(crate) fn build_entry(
     if port != 22 {
         s.push_str(&format!("    port: {}\n", port));
     }
-    s.push_str(&format!("    auth: {}\n", auth));
+    // Emit nested auth block.
+    s.push_str("    auth:\n");
+    s.push_str(&format!("      type: {}\n", auth));
     if let Some(k) = key {
-        s.push_str(&format!("    key: {}\n", k));
+        s.push_str(&format!("      key: {}\n", k));
     }
     s.push_str(&format!(
         "    description: \"{}\"\n",
@@ -352,7 +354,7 @@ mod tests {
         assert!(content.contains("myconn:"));
         assert!(content.contains("host: 10.0.0.1"));
         assert!(content.contains("user: deploy"));
-        assert!(content.contains("auth: key"));
+        assert!(content.contains("type: key"));
         assert!(content.contains("key: ~/.ssh/id_rsa"));
         assert!(content.contains("description:"));
     }
@@ -373,7 +375,7 @@ mod tests {
         run_with_input(Layer::User, dir.path(), &answers).unwrap();
 
         let content = fs::read_to_string(dir.path().join("connections.yaml")).unwrap();
-        assert!(content.contains("auth: password"));
+        assert!(content.contains("type: password"));
         assert!(!content.contains("key:"));
     }
 
@@ -414,7 +416,7 @@ mod tests {
         write_yaml(
             dir.path(),
             "connections.yaml",
-            "version: 1\n\nconnections:\n  existing:\n    host: h\n    user: u\n    auth: key\n    description: \"d\"\n",
+            "version: 1\n\nconnections:\n  existing:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: \"d\"\n",
         );
 
         let answers = [
@@ -439,7 +441,7 @@ mod tests {
         write_yaml(
             dir.path(),
             "connections.yaml",
-            "version: 1\n\nconnections:\n  myconn:\n    host: h\n    user: u\n    auth: key\n    description: \"d\"\n",
+            "version: 1\n\nconnections:\n  myconn:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: \"d\"\n",
         );
 
         let answers = ["myconn", "other.host", "user", "", "password", "Dup", ""];
@@ -485,7 +487,7 @@ mod tests {
     #[test]
     fn test_insert_connection_appends_under_existing_connections_key() {
         let content = "version: 1\n\nconnections:\n  a:\n    host: h\n";
-        let entry = "    host: newhost\n    user: u\n    auth: key\n    description: \"d\"\n";
+        let entry = "    host: newhost\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: \"d\"\n";
         let result = insert_connection(content, "b", entry);
         assert!(result.contains("a:"));
         assert!(result.contains("b:"));
@@ -495,7 +497,7 @@ mod tests {
     #[test]
     fn test_insert_connection_adds_connections_section_when_missing() {
         let content = "version: 1\n";
-        let entry = "    host: h\n    user: u\n    auth: key\n    description: \"d\"\n";
+        let entry = "    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: \"d\"\n";
         let result = insert_connection(content, "srv", entry);
         assert!(result.contains("connections:"));
         assert!(result.contains("srv:"));
@@ -540,7 +542,7 @@ mod tests {
         // Write initial content with looser permissions to simulate existing file.
         fs::write(
             &target,
-            "version: 1\n\nconnections:\n  existing:\n    host: h\n    user: u\n    auth: key\n    description: \"d\"\n",
+            "version: 1\n\nconnections:\n  existing:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: \"d\"\n",
         )
         .unwrap();
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -71,7 +71,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
 
         let empty = TempDir::new().unwrap();
@@ -114,7 +114,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  a:\n    host: h\n    user: u\n    auth: key\n    description: d\n  b:\n    host: h2\n    user: u2\n    auth: key\n    description: d2\n",
+            "connections:\n  a:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n  b:\n    host: h2\n    user: u2\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d2\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -31,12 +31,10 @@ pub fn run(
     // Security: validate the key file before trying to connect.
     // Expand a leading `~` so that the existence and permission checks operate
     // on the real path — Path::new("~/.ssh/id_rsa") does not exist literally.
-    if conn.auth == "key" {
-        if let Some(ref key) = conn.key {
-            let expanded = expand_tilde(key);
-            for w in security::check_key_file(&expanded) {
-                renderer.warn(&w.message);
-            }
+    if let Some(key) = conn.auth.key() {
+        let expanded = expand_tilde(key);
+        for w in security::check_key_file(&expanded) {
+            renderer.warn(&w.message);
         }
     }
 
@@ -193,7 +191,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Prod\n",
+            "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Prod\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
@@ -215,7 +213,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: myhost\n    user: admin\n    auth: key\n    key: ~/.ssh/id_ed25519\n    description: Server\n",
+            "connections:\n  srv:\n    host: myhost\n    user: admin\n    auth:\n      type: key\n      key: ~/.ssh/id_ed25519\n    description: Server\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
@@ -243,7 +241,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  db:\n    host: db.internal\n    user: dbadmin\n    auth: password\n    description: DB\n",
+            "connections:\n  db:\n    host: db.internal\n    user: dbadmin\n    auth:\n      type: password\n    description: DB\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
@@ -264,7 +262,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "docker:\n  image: ghcr.io/org/keys:latest\nconnections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Prod\n",
+            "docker:\n  image: ghcr.io/org/keys:latest\nconnections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Prod\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
@@ -289,7 +287,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "docker:\n  image: ghcr.io/org/keys:latest\nconnections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Prod\n",
+            "docker:\n  image: ghcr.io/org/keys:latest\nconnections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Prod\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
@@ -307,7 +305,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "docker:\n  image: myimage:v1\nconnections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    key: ~/.ssh/k\n    description: d\n",
+            "docker:\n  image: myimage:v1\nconnections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/k\n    description: d\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
@@ -327,7 +325,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: h\n    user: u\n    auth: password\n    description: d\n",
+            "connections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: password\n    description: d\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
@@ -356,7 +354,7 @@ mod tests {
     #[test]
     fn test_print_connecting_key_auth_format() {
         // Use build_args directly — same path as run() uses.
-        use crate::config::{Connection, Layer};
+        use crate::config::{Auth, Connection, Layer};
         use std::path::PathBuf;
 
         let conn = Connection {
@@ -364,8 +362,10 @@ mod tests {
             host: "myhost".to_string(),
             user: "deploy".to_string(),
             port: 22,
-            auth: "key".to_string(),
-            key: Some("~/.ssh/id_rsa".to_string()),
+            auth: Auth::Key {
+                key: "~/.ssh/id_rsa".to_string(),
+                cmd: None,
+            },
             description: String::new(),
             link: None,
             group: None,
@@ -399,7 +399,7 @@ mod tests {
     /// expected single-line format: `[yconn] Connecting: ssh user@host`.
     #[test]
     fn test_print_connecting_password_auth_format() {
-        use crate::config::{Connection, Layer};
+        use crate::config::{Auth, Connection, Layer};
         use std::path::PathBuf;
 
         let conn = Connection {
@@ -407,8 +407,7 @@ mod tests {
             host: "db.internal".to_string(),
             user: "dbadmin".to_string(),
             port: 22,
-            auth: "password".to_string(),
-            key: None,
+            auth: Auth::Password,
             description: String::new(),
             link: None,
             group: None,
@@ -536,7 +535,7 @@ mod tests {
         let cwd = TempDir::new().unwrap();
         let user_dir = TempDir::new().unwrap();
         let yaml = format!(
-            "connections:\n  srv:\n    host: myhost\n    user: {user}\n    auth: password\n    description: d\n"
+            "connections:\n  srv:\n    host: myhost\n    user: {user}\n    auth:\n      type: password\n    description: d\n"
         );
         write_yaml(user_dir.path(), "connections.yaml", &yaml);
         let empty = TempDir::new().unwrap();
@@ -547,7 +546,7 @@ mod tests {
         let cwd = TempDir::new().unwrap();
         let user_dir = TempDir::new().unwrap();
         let yaml = format!(
-            "{users_yaml}connections:\n  srv:\n    host: myhost\n    user: {user}\n    auth: password\n    description: d\n"
+            "{users_yaml}connections:\n  srv:\n    host: myhost\n    user: {user}\n    auth:\n      type: password\n    description: d\n"
         );
         write_yaml(user_dir.path(), "connections.yaml", &yaml);
         let empty = TempDir::new().unwrap();

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -96,7 +96,7 @@ mod tests {
 
     fn simple_conn(name: &str, host: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: u\n    auth: key\n    description: d\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n"
         )
     }
 

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -131,13 +131,13 @@ mod tests {
 
     fn simple_conn(name: &str, host: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
         )
     }
 
     fn conn_with_group(name: &str, host: &str, group: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n    group: {group}\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n    group: {group}\n"
         )
     }
 
@@ -228,7 +228,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -26,8 +26,9 @@ connections:
   #   host: 10.0.1.50
   #   user: deploy
   #   port: 22        # optional, defaults to 22
-  #   auth: key       # key | password
-  #   key: ~/.ssh/id_rsa
+  #   auth:
+  #     type: key      # key | password
+  #     key: ~/.ssh/id_rsa
   #   description: \"Example server\"
   #   link: https://wiki.internal/servers/example   # optional
 ";

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -453,7 +453,7 @@ mod tests {
         let mut s = String::from("version: 1\n\nconnections:\n");
         for (name, host, user) in connections {
             s.push_str(&format!(
-                "  {name}:\n    host: {host}\n    user: {user}\n    auth: password\n    description: \"test\"\n"
+                "  {name}:\n    host: {host}\n    user: {user}\n    auth:\n      type: password\n    description: \"test\"\n"
             ));
         }
         s
@@ -519,7 +519,7 @@ mod tests {
         // Pre-populate target with alpha using a different host.
         fs::write(
             &target_file,
-            "version: 1\n\nconnections:\n  alpha:\n    host: old-host\n    user: old-user\n    auth: password\n    description: \"old\"\n",
+            "version: 1\n\nconnections:\n  alpha:\n    host: old-host\n    user: old-user\n    auth:\n      type: password\n    description: \"old\"\n",
         )
         .unwrap();
 
@@ -559,7 +559,7 @@ mod tests {
 
         fs::write(
             &target_file,
-            "version: 1\n\nconnections:\n  alpha:\n    host: old-host\n    user: old-user\n    auth: password\n    description: \"old\"\n",
+            "version: 1\n\nconnections:\n  alpha:\n    host: old-host\n    user: old-user\n    auth:\n      type: password\n    description: \"old\"\n",
         )
         .unwrap();
 
@@ -636,8 +636,9 @@ mod tests {
 
     #[test]
     fn test_replace_connection_updates_body() {
-        let content = "version: 1\n\nconnections:\n  alpha:\n    host: old\n    user: u\n    auth: password\n    description: \"d\"\n  beta:\n    host: bh\n    user: bu\n    auth: password\n    description: \"d2\"\n";
-        let new_entry = "    host: new\n    user: u\n    auth: password\n    description: \"d\"\n";
+        let content = "version: 1\n\nconnections:\n  alpha:\n    host: old\n    user: u\n    auth:\n      type: password\n    description: \"d\"\n  beta:\n    host: bh\n    user: bu\n    auth:\n      type: password\n    description: \"d2\"\n";
+        let new_entry =
+            "    host: new\n    user: u\n    auth:\n      type: password\n    description: \"d\"\n";
         let result = replace_connection(content, "alpha", new_entry);
         assert!(result.contains("host: new"), "new host not found");
         assert!(!result.contains("host: old"), "old host still present");
@@ -655,7 +656,7 @@ mod tests {
         // Project config with a ${t1user} template in the user field.
         fs::write(
             &project_file,
-            "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"test\"\n",
+            "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: \"test\"\n",
         ).unwrap();
 
         // Provide the prompted value followed by newline (no further stdin needed
@@ -698,7 +699,7 @@ mod tests {
         // Project config with a ${t1user} template.
         fs::write(
             &project_file,
-            "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"test\"\n",
+            "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: \"test\"\n",
         ).unwrap();
 
         // Pre-populate target with the t1user entry already resolved.
@@ -724,7 +725,7 @@ mod tests {
         // Two connections referencing the same ${t1user} key.
         fs::write(
             &project_file,
-            "version: 1\n\nconnections:\n  conn-a:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"a\"\n  conn-b:\n    host: 10.0.0.2\n    user: \"${t1user}\"\n    auth: password\n    description: \"b\"\n",
+            "version: 1\n\nconnections:\n  conn-a:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: \"a\"\n  conn-b:\n    host: 10.0.0.2\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: \"b\"\n",
         ).unwrap();
 
         // Provide a single value — should only be prompted once.

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -135,7 +135,7 @@ fn conn_to_row(c: &Connection) -> ConnectionRow {
         host: c.host.clone(),
         user: c.user.clone(),
         port: c.port,
-        auth: c.auth.clone(),
+        auth: c.auth.type_label().to_string(),
         source: c.layer.label().to_string(),
         description: c.description.clone(),
         shadowed: c.shadowed,
@@ -159,13 +159,13 @@ mod tests {
 
     fn simple_conn(name: &str, host: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
         )
     }
 
     fn conn_with_group(name: &str, host: &str, group: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n    group: {group}\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n    group: {group}\n"
         )
     }
 
@@ -388,7 +388,7 @@ mod tests {
 
     fn conn_yaml_with_user(name: &str, host: &str, user: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: {user}\n    auth: key\n    description: desc\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: {user}\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
         )
     }
 
@@ -473,7 +473,7 @@ mod tests {
         // Two connections: one with a resolved placeholder, one with an unresolved one.
         let yaml = conn_yaml_with_users_section(
             &format!(
-                "connections:\n  srv1:\n    host: 10.0.0.1\n    user: ${{known_user}}\n    auth: key\n    description: desc\n  srv2:\n    host: 10.0.0.2\n    user: ${{unknown_user}}\n    auth: key\n    description: desc\n"
+                "connections:\n  srv1:\n    host: 10.0.0.1\n    user: ${{known_user}}\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n  srv2:\n    host: 10.0.0.2\n    user: ${{unknown_user}}\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
             ),
             "  known_user: admin",
         );
@@ -509,7 +509,7 @@ mod tests {
 
         let yaml = conn_yaml_with_users_section(
             &format!(
-                "connections:\n  srv1:\n    host: 10.0.0.1\n    user: ${{deploy_user}}\n    auth: key\n    description: desc\n  srv2:\n    host: 10.0.0.2\n    user: ${{deploy_user}}\n    auth: key\n    description: desc\n"
+                "connections:\n  srv1:\n    host: 10.0.0.1\n    user: ${{deploy_user}}\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n  srv2:\n    host: 10.0.0.2\n    user: ${{deploy_user}}\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
             ),
             "  deploy_user: admin",
         );

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn test_remove_entry_single_connection() {
-        let content = "version: 1\n\nconnections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n";
+        let content = "version: 1\n\nconnections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n";
         let result = remove_entry(content, "srv").unwrap();
         assert!(!result.contains("srv:"));
         assert!(result.contains("connections:"));
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_remove_entry_leaves_other_connections() {
-        let content = "connections:\n  alpha:\n    host: a\n    user: u\n    auth: key\n    description: d\n  beta:\n    host: b\n    user: u\n    auth: key\n    description: d\n";
+        let content = "connections:\n  alpha:\n    host: a\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n  beta:\n    host: b\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n";
         let result = remove_entry(content, "alpha").unwrap();
         assert!(!result.contains("alpha:"));
         assert!(result.contains("beta:"));
@@ -279,7 +279,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "version: 1\n\nconnections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
+            "version: 1\n\nconnections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
         let sys = TempDir::new().unwrap();
         let cfg = load(dir.path(), None, sys.path());
@@ -314,14 +314,14 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  srv:\n    host: proj\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: proj\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
 
         let sys = TempDir::new().unwrap();
         write_yaml(
             sys.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: sys\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: sys\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
 
         let cfg = load(root.path(), None, sys.path());
@@ -363,14 +363,14 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  srv:\n    host: proj\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: proj\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
 
         let sys = TempDir::new().unwrap();
         write_yaml(
             sys.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: sys\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: sys\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
 
         let cfg = load(root.path(), None, sys.path());
@@ -394,13 +394,13 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  srv:\n    host: proj\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: proj\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
         let sys = TempDir::new().unwrap();
         write_yaml(
             sys.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: sys\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: sys\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
         let cfg = load(root.path(), None, sys.path());
 

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-use crate::config::LoadedConfig;
+use crate::config::{Auth, LoadedConfig};
 use crate::display::{ConnectionDetail, Renderer};
 
 // ─── Dump serialisation types ─────────────────────────────────────────────────
@@ -15,9 +15,7 @@ struct DumpConn {
     host: String,
     user: String,
     port: u16,
-    auth: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    key: Option<String>,
+    auth: Auth,
     description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     link: Option<String>,
@@ -46,7 +44,6 @@ fn build_dump_yaml(cfg: &LoadedConfig) -> Result<String> {
                 user: conn.user.clone(),
                 port: conn.port,
                 auth: conn.auth.clone(),
-                key: conn.key.clone(),
                 description: conn.description.clone(),
                 link: conn.link.clone(),
                 group: conn.group.clone(),
@@ -144,8 +141,9 @@ pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str) -> Result<()> {
         host: conn.host.clone(),
         user: conn.user.clone(),
         port: conn.port,
-        auth: conn.auth.clone(),
-        key: conn.key.clone(),
+        auth: conn.auth.type_label().to_string(),
+        key: conn.auth.key().map(str::to_string),
+        cmd: conn.auth.cmd().map(str::to_string),
         description: conn.description.clone(),
         link: conn.link.clone(),
         source_label: conn.layer.label().to_string(),
@@ -193,7 +191,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Test server\n",
+            "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Test server\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
@@ -229,7 +227,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  web:\n    host: 1.2.3.4\n    user: ${testuser}\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Web server\nusers:\n  testuser: alice\n",
+            "connections:\n  web:\n    host: 1.2.3.4\n    user: ${testuser}\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Web server\nusers:\n  testuser: alice\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
@@ -342,7 +340,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Alpha\n  beta:\n    host: 10.0.0.2\n    user: admin\n    auth: password\n    description: Beta\nusers:\n  k: v\n",
+            "connections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Alpha\n  beta:\n    host: 10.0.0.2\n    user: admin\n    auth:\n      type: password\n    description: Beta\nusers:\n  k: v\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
@@ -379,7 +377,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Production server\n",
+            "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Production server\n",
         );
 
         let empty = TempDir::new().unwrap();
@@ -394,7 +392,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
+            "connections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
@@ -421,7 +419,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  srv:\n    host: 1.2.3.4\n    user: admin\n    port: 2222\n    auth: key\n    key: ~/.ssh/id_ed25519\n    description: Test\n    link: https://wiki.example.com\n",
+            "connections:\n  srv:\n    host: 1.2.3.4\n    user: admin\n    port: 2222\n    auth:\n      type: key\n      key: ~/.ssh/id_ed25519\n    description: Test\n    link: https://wiki.example.com\n",
         );
 
         let empty = TempDir::new().unwrap();
@@ -436,7 +434,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  db:\n    host: db.internal\n    user: dbadmin\n    auth: password\n    description: Database\n",
+            "connections:\n  db:\n    host: db.internal\n    user: dbadmin\n    auth:\n      type: password\n    description: Database\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());

--- a/src/commands/ssh_config.rs
+++ b/src/commands/ssh_config.rs
@@ -69,7 +69,7 @@ pub fn render_ssh_config(connections: &[Connection], skip_user: bool) -> String 
 
         // All comment lines appear contiguously before the Host line.
         out.push_str(&format!("# description: {}\n", conn.description));
-        out.push_str(&format!("# auth: {}\n", conn.auth));
+        out.push_str(&format!("# auth: {}\n", conn.auth.type_label()));
         if let Some(link) = &conn.link {
             out.push_str(&format!("# link: {link}\n"));
         }
@@ -88,7 +88,7 @@ pub fn render_ssh_config(connections: &[Connection], skip_user: bool) -> String 
         if conn.port != 22 {
             out.push_str(&format!("    Port {}\n", conn.port));
         }
-        if let Some(key) = &conn.key {
+        if let Some(key) = conn.auth.key() {
             out.push_str(&format!("    IdentityFile {key}\n"));
         }
         out.push('\n');
@@ -628,7 +628,7 @@ pub fn run_enable(home: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Connection, Layer};
+    use crate::config::{Auth, Connection, Layer};
     use std::path::PathBuf;
 
     fn make_conn(
@@ -636,16 +636,22 @@ mod tests {
         host: &str,
         user: &str,
         port: u16,
-        auth: &str,
+        auth_type: &str,
         key: Option<&str>,
     ) -> Connection {
+        let auth = match auth_type {
+            "key" => Auth::Key {
+                key: key.unwrap_or("~/.ssh/id_rsa").to_string(),
+                cmd: None,
+            },
+            _ => Auth::Password,
+        };
         Connection {
             name: name.to_string(),
             host: host.to_string(),
             user: user.to_string(),
             port,
-            auth: auth.to_string(),
-            key: key.map(|s| s.to_string()),
+            auth,
             description: format!("{name} description"),
             link: None,
             group: None,
@@ -930,7 +936,7 @@ mod tests {
     #[test]
     fn test_dollar_user_expanded_from_override() {
         // Use --user user:alice override (deterministic, no dependency on $USER env var).
-        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${user}\"\n    auth: password\n    description: test\n";
+        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${user}\"\n    auth:\n      type: password\n    description: test\n";
         let mut overrides = HashMap::new();
         overrides.insert("user".to_string(), "alice".to_string());
         let (out, _warnings) = render_expanded(yaml, &overrides, false);
@@ -960,7 +966,7 @@ mod tests {
 
     #[test]
     fn test_named_key_expanded_from_users_map() {
-        let yaml = "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${testuser}\"\n    auth: password\n    description: test\n";
+        let yaml = "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${testuser}\"\n    auth:\n      type: password\n    description: test\n";
         let (out, warnings) = render_expanded(yaml, &HashMap::new(), false);
         assert!(
             out.contains("    User ops\n"),
@@ -981,7 +987,7 @@ mod tests {
 
     #[test]
     fn test_user_override_overrides_users_map() {
-        let yaml = "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${testuser}\"\n    auth: password\n    description: test\n";
+        let yaml = "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${testuser}\"\n    auth:\n      type: password\n    description: test\n";
         let mut overrides = HashMap::new();
         overrides.insert("testuser".to_string(), "alice".to_string());
         let (out, warnings) = render_expanded(yaml, &overrides, false);
@@ -994,7 +1000,7 @@ mod tests {
 
     #[test]
     fn test_multiple_user_overrides_all_applied() {
-        let yaml = "users:\n  k1: \"a\"\nconnections:\n  c1:\n    host: h1\n    user: \"${k1}\"\n    auth: password\n    description: d1\n  c2:\n    host: h2\n    user: \"${user}\"\n    auth: password\n    description: d2\n";
+        let yaml = "users:\n  k1: \"a\"\nconnections:\n  c1:\n    host: h1\n    user: \"${k1}\"\n    auth:\n      type: password\n    description: d1\n  c2:\n    host: h2\n    user: \"${user}\"\n    auth:\n      type: password\n    description: d2\n";
         let mut overrides = HashMap::new();
         overrides.insert("k1".to_string(), "carol".to_string());
         overrides.insert("user".to_string(), "dave".to_string());
@@ -1008,7 +1014,7 @@ mod tests {
 
     #[test]
     fn test_unresolved_template_produces_warning() {
-        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${nokey}\"\n    auth: password\n    description: test\n";
+        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${nokey}\"\n    auth:\n      type: password\n    description: test\n";
         let (_out, warnings) = render_expanded(yaml, &HashMap::new(), false);
         assert!(
             !warnings.is_empty(),
@@ -1274,7 +1280,7 @@ mod tests {
     /// the resolved value.
     #[test]
     fn test_run_install_impl_unresolved_key_prompts_and_resolves() {
-        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth: password\n    description: test\n";
+        let yaml = "connections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: test\n";
         let (cfg, _user_dir) = load_cfg(yaml);
 
         let home = tempfile::TempDir::new().unwrap();
@@ -1326,7 +1332,7 @@ mod tests {
     /// `run_install_impl` with all keys already resolved produces no prompts.
     #[test]
     fn test_run_install_impl_resolved_keys_no_prompt() {
-        let yaml = "users:\n  t1user: \"bob\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth: password\n    description: test\n";
+        let yaml = "users:\n  t1user: \"bob\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: test\n";
         let (cfg, _user_dir) = load_cfg(yaml);
 
         let home = tempfile::TempDir::new().unwrap();

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -511,7 +511,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "version: 1\n\nusers:\n  mykey: \"val\"\nconnections:\n  srv:\n    host: h\n    user: u\n    auth: key\n    description: d\n",
+            "version: 1\n\nusers:\n  mykey: \"val\"\nconnections:\n  srv:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::security;
 
@@ -56,9 +56,7 @@ struct RawConn {
     #[serde(default = "default_port")]
     port: u16,
     #[serde(default)]
-    auth: Option<String>,
-    #[serde(default)]
-    key: Option<String>,
+    auth: Option<Auth>,
     #[serde(default)]
     description: Option<String>,
     #[serde(default)]
@@ -67,6 +65,53 @@ struct RawConn {
     /// to no group and are always shown unless a group filter is active.
     #[serde(default)]
     group: Option<String>,
+}
+
+// ─── Auth enum ───────────────────────────────────────────────────────────────
+
+/// Structured authentication configuration for a connection.
+///
+/// Serialised as an internally-tagged YAML mapping: `{ type: key, key: ... }`.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[serde(tag = "type")]
+pub enum Auth {
+    /// Key-based authentication. `key` is the path to the private key file.
+    /// `cmd` is an optional shell command (parsed and stored only — not executed).
+    #[serde(rename = "key")]
+    Key {
+        key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cmd: Option<String>,
+    },
+    /// Password authentication — SSH prompts natively.
+    #[serde(rename = "password")]
+    Password,
+}
+
+impl Auth {
+    /// Return a human-readable label for the auth type.
+    pub fn type_label(&self) -> &str {
+        match self {
+            Auth::Key { .. } => "key",
+            Auth::Password => "password",
+        }
+    }
+
+    /// Return the key path, if any.
+    pub fn key(&self) -> Option<&str> {
+        match self {
+            Auth::Key { ref key, .. } => Some(key.as_str()),
+            Auth::Password => None,
+        }
+    }
+
+    /// Return the cmd field, if any.
+    pub fn cmd(&self) -> Option<&str> {
+        match self {
+            Auth::Key { ref cmd, .. } => cmd.as_deref(),
+            Auth::Password => None,
+        }
+    }
 }
 
 fn default_port() -> u16 {
@@ -100,8 +145,7 @@ pub struct Connection {
     pub host: String,
     pub user: String,
     pub port: u16,
-    pub auth: String,
-    pub key: Option<String>,
+    pub auth: Auth,
     pub description: String,
     pub link: Option<String>,
     /// Optional inline group tag from the YAML `group:` field.
@@ -646,6 +690,12 @@ fn validate_connections(path: &Path, connections: &HashMap<String, RawConn>) -> 
     Ok(())
 }
 
+/// Default auth value used when auth is None (should not happen after
+/// validation, but provides a safe fallback).
+fn default_auth() -> Auth {
+    Auth::Password
+}
+
 struct LayerData {
     found: bool,
     count: usize,
@@ -824,8 +874,7 @@ fn build_connection(
         host: raw.host.clone().unwrap_or_default(),
         user: raw.user.clone().unwrap_or_default(),
         port: raw.port,
-        auth: raw.auth.clone().unwrap_or_default(),
-        key: raw.key.clone(),
+        auth: raw.auth.clone().unwrap_or_else(default_auth),
         description: raw.description.clone().unwrap_or_default(),
         link: raw.link.clone(),
         group: raw.group.clone(),
@@ -912,13 +961,13 @@ mod tests {
 
     fn simple_conn(name: &str, host: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
         )
     }
 
     fn conn_with_group(name: &str, host: &str, group: &str) -> String {
         format!(
-            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth: key\n    description: desc\n    group: {group}\n"
+            "connections:\n  {name}:\n    host: {host}\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n    group: {group}\n"
         )
     }
 
@@ -1336,7 +1385,7 @@ mod tests {
             &format!(
                 "{}\n{}",
                 simple_conn("alpha", "1.0.0.1"),
-                "  beta:\n    host: 2.0.0.2\n    user: u\n    auth: key\n    description: d\n"
+                "  beta:\n    host: 2.0.0.2\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n"
             ),
         );
 
@@ -1491,7 +1540,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  a:\n    host: h\n    user: u\n    auth: key\n    description: d\n  b:\n    host: h2\n    user: u2\n    auth: key\n    description: d2\n",
+            "connections:\n  a:\n    host: h\n    user: u\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d\n  b:\n    host: h2\n    user: u2\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: d2\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1545,7 +1594,7 @@ mod tests {
             "{}\n{}",
             conn_with_group("work-srv", "10.0.0.1", "work"),
             // Simple conn in same connections block — just append raw
-            "  plain-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n"
+            "  plain-srv:\n    host: 10.0.0.2\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
         );
         write_yaml(user.path(), "connections.yaml", &yaml);
         let empty = TempDir::new().unwrap();
@@ -1563,7 +1612,7 @@ mod tests {
         let yaml = format!(
             "{}\n{}",
             conn_with_group("work-srv", "10.0.0.1", "work"),
-            "  plain-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n"
+            "  plain-srv:\n    host: 10.0.0.2\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n"
         );
         write_yaml(user.path(), "connections.yaml", &yaml);
         let empty = TempDir::new().unwrap();
@@ -1632,7 +1681,7 @@ mod tests {
         let yaml = format!(
             "{}\n{}",
             conn_with_group("work-srv", "10.0.0.1", "work"),
-            "  private-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n    group: private\n"
+            "  private-srv:\n    host: 10.0.0.2\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n    group: private\n"
         );
         write_yaml(user.path(), "connections.yaml", &yaml);
         let empty = TempDir::new().unwrap();
@@ -1652,7 +1701,7 @@ mod tests {
         let yaml = format!(
             "{}\n{}",
             conn_with_group("z-srv", "10.0.0.1", "zebra"),
-            "  a-srv:\n    host: 10.0.0.2\n    user: user\n    auth: key\n    description: desc\n    group: alpha\n"
+            "  a-srv:\n    host: 10.0.0.2\n    user: user\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: desc\n    group: alpha\n"
         );
         write_yaml(user.path(), "connections.yaml", &yaml);
         let empty = TempDir::new().unwrap();
@@ -1704,7 +1753,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Wildcard web\n",
+            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Wildcard web\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1725,7 +1774,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Wildcard web\n",
+            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Wildcard web\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1747,7 +1796,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  web-*:\n    host: ph1\n    user: deploy\n    auth: password\n    description: Web wildcard\n  \"?eb-prod\":\n    host: ph2\n    user: admin\n    auth: password\n    description: Prefix wildcard\n",
+            "connections:\n  web-*:\n    host: ph1\n    user: deploy\n    auth:\n      type: password\n    description: Web wildcard\n  \"?eb-prod\":\n    host: ph2\n    user: admin\n    auth:\n      type: password\n    description: Prefix wildcard\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1773,7 +1822,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  web-prod:\n    host: exact-host\n    user: exact-user\n    auth: password\n    description: Exact match\n  web-*:\n    host: wildcard-host\n    user: wildcard-user\n    auth: password\n    description: Wildcard\n",
+            "connections:\n  web-prod:\n    host: exact-host\n    user: exact-user\n    auth:\n      type: password\n    description: Exact match\n  web-*:\n    host: wildcard-host\n    user: wildcard-user\n    auth:\n      type: password\n    description: Wildcard\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1797,7 +1846,7 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  host-*:\n    host: proj-host\n    user: project-user\n    auth: password\n    description: Project wildcard\n",
+            "connections:\n  host-*:\n    host: proj-host\n    user: project-user\n    auth:\n      type: password\n    description: Project wildcard\n",
         );
 
         let user = TempDir::new().unwrap();
@@ -1805,7 +1854,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  host-*:\n    host: user-host\n    user: user-user\n    auth: password\n    description: User wildcard\n",
+            "connections:\n  host-*:\n    host: user-host\n    user: user-user\n    auth:\n      type: password\n    description: User wildcard\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1825,7 +1874,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  web-?:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Single char wildcard\n",
+            "connections:\n  web-?:\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Single char wildcard\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1847,7 +1896,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  server*:\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth: password\n    description: Corp servers\n",
+            "connections:\n  server*:\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth:\n      type: password\n    description: Corp servers\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1866,7 +1915,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Web servers\n",
+            "connections:\n  web-*:\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Web servers\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1885,7 +1934,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  myconn:\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth: password\n    description: My connection\n",
+            "connections:\n  myconn:\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth:\n      type: password\n    description: My connection\n",
         );
         let empty = TempDir::new().unwrap();
 
@@ -1905,7 +1954,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Range servers\n",
+            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Range servers\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
@@ -1922,7 +1971,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Range servers\n",
+            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Range servers\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
@@ -1939,7 +1988,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Range servers\n",
+            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Range servers\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
@@ -1956,7 +2005,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth: password\n    description: Range servers\n",
+            "connections:\n  \"server[1..10]\":\n    host: placeholder\n    user: deploy\n    auth:\n      type: password\n    description: Range servers\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
@@ -1975,7 +2024,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: ph1\n    user: deploy\n    auth: password\n    description: Range\n  server*:\n    host: ph2\n    user: admin\n    auth: password\n    description: Glob\n",
+            "connections:\n  \"server[1..10]\":\n    host: ph1\n    user: deploy\n    auth:\n      type: password\n    description: Range\n  server*:\n    host: ph2\n    user: admin\n    auth:\n      type: password\n    description: Glob\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
@@ -1997,7 +2046,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  server5:\n    host: exact-host\n    user: exact-user\n    auth: password\n    description: Exact\n  \"server[1..10]\":\n    host: range-host\n    user: range-user\n    auth: password\n    description: Range\n",
+            "connections:\n  server5:\n    host: exact-host\n    user: exact-user\n    auth:\n      type: password\n    description: Exact\n  \"server[1..10]\":\n    host: range-host\n    user: range-user\n    auth:\n      type: password\n    description: Range\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());
@@ -2016,13 +2065,13 @@ mod tests {
         write_yaml(
             &yconn,
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: proj-host\n    user: project-user\n    auth: password\n    description: Project range\n",
+            "connections:\n  \"server[1..10]\":\n    host: proj-host\n    user: project-user\n    auth:\n      type: password\n    description: Project range\n",
         );
         let user = TempDir::new().unwrap();
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: user-host\n    user: user-user\n    auth: password\n    description: User range\n",
+            "connections:\n  \"server[1..10]\":\n    host: user-host\n    user: user-user\n    auth:\n      type: password\n    description: User range\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(root.path(), Some(user.path()), empty.path());
@@ -2040,7 +2089,7 @@ mod tests {
         write_yaml(
             user.path(),
             "connections.yaml",
-            "connections:\n  \"server[1..10]\":\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth: password\n    description: Corp servers\n",
+            "connections:\n  \"server[1..10]\":\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth:\n      type: password\n    description: Corp servers\n",
         );
         let empty = TempDir::new().unwrap();
         let cfg = load_test(cwd.path(), Some(user.path()), empty.path());

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -14,7 +14,7 @@ use std::ffi::CString;
 
 use anyhow::{Context, Result};
 
-use crate::config::Connection;
+use crate::config::{Auth, Connection};
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -40,11 +40,9 @@ pub fn build_args(conn: &Connection) -> Vec<String> {
     // the sole authority for all SSH connection parameters.
     let mut args = vec!["ssh".to_string(), "-F".to_string(), "/dev/null".to_string()];
 
-    if conn.auth == "key" {
-        if let Some(ref key) = conn.key {
-            args.push("-i".to_string());
-            args.push(key.clone());
-        }
+    if let Auth::Key { ref key, .. } = conn.auth {
+        args.push("-i".to_string());
+        args.push(key.clone());
     }
 
     if conn.port != 22 {
@@ -109,16 +107,28 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use crate::config::{Connection, Layer};
+    use crate::config::{Auth, Connection, Layer};
 
-    fn make_conn(auth: &str, key: Option<&str>, port: u16, host: &str, user: &str) -> Connection {
+    fn make_conn(
+        auth_type: &str,
+        key: Option<&str>,
+        port: u16,
+        host: &str,
+        user: &str,
+    ) -> Connection {
+        let auth = match auth_type {
+            "key" => Auth::Key {
+                key: key.unwrap_or("~/.ssh/id_rsa").to_string(),
+                cmd: None,
+            },
+            _ => Auth::Password,
+        };
         Connection {
             name: "test".to_string(),
             host: host.to_string(),
             user: user.to_string(),
             port,
-            auth: auth.to_string(),
-            key: key.map(str::to_string),
+            auth,
             description: String::new(),
             link: None,
             group: None,
@@ -320,11 +330,12 @@ mod tests {
     // ── additional edge cases ─────────────────────────────────────────────────
 
     #[test]
-    fn test_key_auth_without_key_field() {
-        // auth=key but no key path — no -i flag emitted
-        let conn = make_conn("key", None, 22, "myhost", "user");
+    fn test_key_auth_always_has_key_flag() {
+        // Auth::Key always includes a key path, so -i is always emitted.
+        let conn = make_conn("key", Some("~/.ssh/id_rsa"), 22, "myhost", "user");
         let args = build_args(&conn);
-        assert_eq!(args, vec!["ssh", "-F", "/dev/null", "user@myhost"]);
+        assert!(args.contains(&"-i".to_string()));
+        assert!(args.contains(&"~/.ssh/id_rsa".to_string()));
     }
 
     #[test]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -27,6 +27,7 @@ pub struct ConnectionDetail {
     pub port: u16,
     pub auth: String,
     pub key: Option<String>,
+    pub cmd: Option<String>,
     pub description: String,
     pub link: Option<String>,
     pub source_label: String,
@@ -226,6 +227,9 @@ impl Renderer {
         out.push_str(&format!("  {}  {}\n", pad("Auth:", LW), detail.auth));
         if let Some(key) = &detail.key {
             out.push_str(&format!("  {}  {}\n", pad("Key:", LW), key));
+        }
+        if let Some(cmd) = &detail.cmd {
+            out.push_str(&format!("  {}  {}\n", pad("Cmd:", LW), cmd));
         }
         out.push_str(&format!(
             "  {}  {}\n",
@@ -621,6 +625,7 @@ mod tests {
             port: 22,
             auth: "key".into(),
             key: Some("~/.ssh/prod_deploy_key".into()),
+            cmd: None,
             description: "Primary production web server".into(),
             link: Some("https://wiki.internal/servers/prod-web".into()),
             source_label: "project".into(),
@@ -652,6 +657,7 @@ mod tests {
             port: 22,
             auth: "password".into(),
             key: None,
+            cmd: None,
             description: "Staging DB".into(),
             link: None,
             source_label: "user".into(),

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_credential_fields_clean_yaml() {
-        let yaml = "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n";
+        let yaml = "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n";
         let path = std::path::Path::new("/repo/.yconn/connections.yaml");
         let warnings = check_credential_fields(path, yaml);
         assert!(warnings.is_empty());

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -192,7 +192,7 @@ fn conn_key(name: &str, host: &str, user: &str, port: Option<u16>, key: &str) ->
         None => String::new(),
     };
     format!(
-        "connections:\n  {name}:\n    host: {host}\n    user: {user}{port_line}\n    auth: key\n    key: {key}\n    description: test connection\n"
+        "connections:\n  {name}:\n    host: {host}\n    user: {user}{port_line}\n    auth:\n      type: key\n      key: {key}\n    description: test connection\n"
     )
 }
 
@@ -202,7 +202,7 @@ fn conn_password(name: &str, host: &str, user: &str, port: Option<u16>) -> Strin
         None => String::new(),
     };
     format!(
-        "connections:\n  {name}:\n    host: {host}\n    user: {user}{port_line}\n    auth: password\n    description: test connection\n"
+        "connections:\n  {name}:\n    host: {host}\n    user: {user}{port_line}\n    auth:\n      type: password\n    description: test connection\n"
     )
 }
 
@@ -674,7 +674,7 @@ fn parse_error_minimal_valid_project_config() {
     // simulate a manually created file with all required fields present.
     env.write_project_config(
         "connections",
-        "connections:\n  my-server:\n    host: 10.0.0.1\n    user: admin\n    auth: password\n    description: My server\n",
+        "connections:\n  my-server:\n    host: 10.0.0.1\n    user: admin\n    auth:\n      type: password\n    description: My server\n",
     );
 
     let out = env.run(&["list"]);
@@ -698,7 +698,7 @@ fn parse_error_minimal_valid_user_config() {
     // Write directly to the user layer config directory.
     env.write_user_config(
         "connections",
-        "connections:\n  user-server:\n    host: 192.168.1.5\n    user: root\n    auth: password\n    description: User server\n",
+        "connections:\n  user-server:\n    host: 192.168.1.5\n    user: root\n    auth:\n      type: password\n    description: User server\n",
     );
 
     let out = env.run(&["list"]);
@@ -723,7 +723,7 @@ fn parse_error_missing_required_field() {
     // 'host' field is intentionally absent.
     env.write_project_config(
         "connections",
-        "connections:\n  bad-server:\n    user: admin\n    auth: password\n    description: Missing host\n",
+        "connections:\n  bad-server:\n    user: admin\n    auth:\n      type: password\n    description: Missing host\n",
     );
 
     let out = env.run(&["list"]);
@@ -831,7 +831,7 @@ fn wildcard_pattern_match_ssh_receives_input_as_host() {
     // Pattern "web-*" in user config — any "web-<something>" input matches.
     env.write_user_config(
         "connections",
-        "connections:\n  web-*:\n    host: placeholder.internal\n    user: deploy\n    auth: password\n    description: Wildcard web servers\n",
+        "connections:\n  web-*:\n    host: placeholder.internal\n    user: deploy\n    auth:\n      type: password\n    description: Wildcard web servers\n",
     );
 
     // Connect using a concrete hostname that matches the pattern.
@@ -861,7 +861,7 @@ fn wildcard_conflict_exits_nonzero_with_pattern_names_in_stderr() {
     // Note: a bare `*` at the start of a YAML key is a YAML anchor — quote it.
     env.write_user_config(
         "connections",
-        "connections:\n  web-*:\n    host: ph1\n    user: deploy\n    auth: password\n    description: Web wildcard\n  \"?eb-prod\":\n    host: ph2\n    user: admin\n    auth: password\n    description: Prefix wildcard\n",
+        "connections:\n  web-*:\n    host: ph1\n    user: deploy\n    auth:\n      type: password\n    description: Web wildcard\n  \"?eb-prod\":\n    host: ph2\n    user: admin\n    auth:\n      type: password\n    description: Prefix wildcard\n",
     );
 
     let out = env.run_in_container(&["connect", "web-prod"]);
@@ -889,7 +889,7 @@ fn wildcard_name_template_in_host_expands_to_fqdn() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  server*:\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth: password\n    description: Corp servers\n",
+        "connections:\n  server*:\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth:\n      type: password\n    description: Corp servers\n",
     );
 
     let out = env.run_in_container(&["connect", "server01"]);
@@ -916,7 +916,7 @@ fn range_pattern_with_name_template_expands_to_fqdn() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  \"server[1..10]\":\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth: password\n    description: Corp servers\n",
+        "connections:\n  \"server[1..10]\":\n    host: \"${name}.corp.com\"\n    user: deploy\n    auth:\n      type: password\n    description: Corp servers\n",
     );
 
     let out = env.run_in_container(&["connect", "server5"]);
@@ -941,7 +941,7 @@ fn range_conflict_with_glob_exits_nonzero_with_pattern_names_in_stderr() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  \"server[1..10]\":\n    host: ph1\n    user: deploy\n    auth: password\n    description: Range pattern\n  server*:\n    host: ph2\n    user: admin\n    auth: password\n    description: Glob pattern\n",
+        "connections:\n  \"server[1..10]\":\n    host: ph1\n    user: deploy\n    auth:\n      type: password\n    description: Range pattern\n  server*:\n    host: ph2\n    user: admin\n    auth:\n      type: password\n    description: Glob pattern\n",
     );
 
     let out = env.run_in_container(&["connect", "server5"]);
@@ -971,7 +971,7 @@ fn ssh_config_install_writes_host_blocks_and_include() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  prod-web:\n    host: 10.0.1.50\n    user: deploy\n    auth: key\n    key: ~/.ssh/prod_key\n    description: Production web\n  staging-db:\n    host: staging.internal\n    user: dbadmin\n    port: 2222\n    auth: password\n    description: Staging database\n",
+        "connections:\n  prod-web:\n    host: 10.0.1.50\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/prod_key\n    description: Production web\n  staging-db:\n    host: staging.internal\n    user: dbadmin\n    port: 2222\n    auth:\n      type: password\n    description: Staging database\n",
     );
 
     let out = env.run(&["ssh-config", "install"]);
@@ -1052,7 +1052,7 @@ fn ssh_config_install_dry_run_prints_to_stdout_no_files_written() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  myhost:\n    host: 192.168.1.1\n    user: admin\n    auth: password\n    description: My host\n",
+        "connections:\n  myhost:\n    host: 192.168.1.1\n    user: admin\n    auth:\n      type: password\n    description: My host\n",
     );
 
     let out = env.run(&["ssh-config", "install", "--dry-run"]);
@@ -1079,7 +1079,7 @@ fn ssh_config_user_override_renders_expanded_user_line() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: \"${user}\"\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: \"${user}\"\n    auth:\n      type: password\n    description: test\n",
     );
 
     let out = env.run(&["ssh-config", "install", "--dry-run", "--user", "user:alice"]);
@@ -1103,7 +1103,7 @@ fn ssh_config_skip_user_omits_user_lines() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: test\n",
     );
 
     let out = env.run(&["ssh-config", "install", "--dry-run", "--skip-user"]);
@@ -1129,7 +1129,7 @@ fn ssh_config_unresolved_user_template_prompts_and_resolves() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: myhost\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: test\n",
     );
 
     // Provide the value via stdin.
@@ -1171,7 +1171,7 @@ fn ssh_config_preserves_foreign_host_blocks() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  prod-web:\n    host: 10.0.1.50\n    user: deploy\n    auth: password\n    description: Production web\n",
+        "connections:\n  prod-web:\n    host: 10.0.1.50\n    user: deploy\n    auth:\n      type: password\n    description: Production web\n",
     );
 
     // Pre-populate yconn-connections with a foreign Host block that yconn
@@ -1221,7 +1221,7 @@ fn ssh_config_two_runs_accumulate_blocks() {
     // First run: write project config with one connection.
     env.write_user_config(
         "connections",
-        "connections:\n  first-host:\n    host: 10.0.1.1\n    user: alice\n    auth: password\n    description: First host\n",
+        "connections:\n  first-host:\n    host: 10.0.1.1\n    user: alice\n    auth:\n      type: password\n    description: First host\n",
     );
     let out1 = env.run(&["ssh-config", "install"]);
     TestEnv::assert_ok(&out1);
@@ -1230,7 +1230,7 @@ fn ssh_config_two_runs_accumulate_blocks() {
     let user_config_path = env.xdg_config.path().join("yconn").join("connections.yaml");
     fs::write(
         &user_config_path,
-        "connections:\n  second-host:\n    host: 10.0.1.2\n    user: bob\n    auth: password\n    description: Second host\n",
+        "connections:\n  second-host:\n    host: 10.0.1.2\n    user: bob\n    auth:\n      type: password\n    description: Second host\n",
     )
     .unwrap();
     let out2 = env.run(&["ssh-config", "install"]);
@@ -1259,7 +1259,7 @@ fn ssh_config_print_outputs_host_blocks_to_stdout() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  myhost:\n    host: 192.168.1.5\n    user: admin\n    auth: password\n    description: My host\n",
+        "connections:\n  myhost:\n    host: 192.168.1.5\n    user: admin\n    auth:\n      type: password\n    description: My host\n",
     );
 
     let out = env.run(&["ssh-config", "print"]);
@@ -1295,7 +1295,7 @@ fn ssh_config_print_skip_user_omits_user_lines() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: test\n",
     );
 
     let out = env.run(&["ssh-config", "print", "--skip-user"]);
@@ -1322,7 +1322,7 @@ fn ssh_config_uninstall_removes_file_and_include_line() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: test\n",
     );
 
     // Install first.
@@ -1381,7 +1381,7 @@ fn ssh_config_disable_removes_include_line_keeps_file() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: test\n",
     );
 
     // Install first.
@@ -1419,7 +1419,7 @@ fn ssh_config_enable_adds_include_line_when_absent() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: test\n",
     );
 
     // Install then disable to remove Include.
@@ -1453,7 +1453,7 @@ fn ssh_config_enable_noop_when_include_already_present() {
 
     env.write_user_config(
         "connections",
-        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: test\n",
+        "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: test\n",
     );
 
     // Install to set up Include line.
@@ -1549,7 +1549,7 @@ fn connect_user_override_expands_dollar_user() {
     env.write_user_config(
         "connections",
         &format!(
-            "connections:\n  srv:\n    host: myhost\n    user: \"${{user}}\"\n    auth: key\n    key: {key}\n    description: test\n"
+            "connections:\n  srv:\n    host: myhost\n    user: \"${{user}}\"\n    auth:\n      type: key\n      key: {key}\n    description: test\n"
         ),
     );
 
@@ -1572,7 +1572,7 @@ fn connect_named_users_map_entry_expands_in_user_field() {
     env.write_user_config(
         "connections",
         &format!(
-            "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${{testuser}}\"\n    auth: key\n    key: {key}\n    description: test\n"
+            "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${{testuser}}\"\n    auth:\n      type: key\n      key: {key}\n    description: test\n"
         ),
     );
 
@@ -1595,7 +1595,7 @@ fn connect_user_override_shadows_config_users_entry() {
     env.write_user_config(
         "connections",
         &format!(
-            "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${{testuser}}\"\n    auth: key\n    key: {key}\n    description: test\n"
+            "users:\n  testuser: \"ops\"\nconnections:\n  srv:\n    host: myhost\n    user: \"${{testuser}}\"\n    auth:\n      type: key\n      key: {key}\n    description: test\n"
         ),
     );
 
@@ -1667,7 +1667,7 @@ fn show_dump_outputs_merged_config_as_yaml() {
     let env = TestEnv::new();
     env.write_project_config(
         "connections",
-        "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth: key\n    key: ~/.ssh/id_rsa\n    description: Production\n  staging:\n    host: 10.0.0.2\n    user: admin\n    auth: password\n    description: Staging\nusers:\n  testuser: alice\n  mybot: botuser\n",
+        "connections:\n  prod:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: ~/.ssh/id_rsa\n    description: Production\n  staging:\n    host: 10.0.0.2\n    user: admin\n    auth:\n      type: password\n    description: Staging\nusers:\n  testuser: alice\n  mybot: botuser\n",
     );
     let out = env.run(&["connections", "show", "--dump"]);
     TestEnv::assert_ok(&out);
@@ -1780,7 +1780,7 @@ fn show_name_still_works_after_dump_flag_added() {
     let env = TestEnv::new();
     env.write_project_config(
         "connections",
-        "connections:\n  web:\n    host: 1.2.3.4\n    user: ops\n    auth: password\n    description: Web\n",
+        "connections:\n  web:\n    host: 1.2.3.4\n    user: ops\n    auth:\n      type: password\n    description: Web\n",
     );
     let out = env.run(&["connections", "show", "web"]);
     TestEnv::assert_ok(&out);
@@ -1803,7 +1803,7 @@ fn show_name_and_dump_together_errors() {
     let env = TestEnv::new();
     env.write_project_config(
         "connections",
-        "connections:\n  web:\n    host: 1.2.3.4\n    user: ops\n    auth: password\n    description: Web\n",
+        "connections:\n  web:\n    host: 1.2.3.4\n    user: ops\n    auth:\n      type: password\n    description: Web\n",
     );
     let out = env.run(&["connections", "show", "web", "--dump"]);
     assert!(!out.status.success(), "expected non-zero exit");
@@ -1819,7 +1819,7 @@ fn install_copies_new_connections_to_user_layer() {
 
     env.write_project_config(
         "connections",
-        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: \"Alpha server\"\n  beta:\n    host: 10.0.0.2\n    user: ops\n    auth: password\n    description: \"Beta server\"\n",
+        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: \"Alpha server\"\n  beta:\n    host: 10.0.0.2\n    user: ops\n    auth:\n      type: password\n    description: \"Beta server\"\n",
     );
 
     let out = env.run(&["install"]);
@@ -1860,13 +1860,13 @@ fn install_updates_existing_with_y_and_appends_new() {
     // Project config: alpha (updated host) and beta (new).
     env.write_project_config(
         "connections",
-        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.99\n    user: deploy\n    auth: password\n    description: \"Alpha updated\"\n  beta:\n    host: 10.0.0.2\n    user: ops\n    auth: password\n    description: \"Beta server\"\n",
+        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.99\n    user: deploy\n    auth:\n      type: password\n    description: \"Alpha updated\"\n  beta:\n    host: 10.0.0.2\n    user: ops\n    auth:\n      type: password\n    description: \"Beta server\"\n",
     );
 
     // Pre-populate user layer with alpha at old host.
     env.write_user_config(
         "connections",
-        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth: password\n    description: \"Alpha old\"\n",
+        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: \"Alpha old\"\n",
     );
 
     // Answer `y` to the update prompt for alpha.
@@ -1909,7 +1909,7 @@ fn install_missing_user_variable_prompts_and_writes_value() {
 
     env.write_project_config(
         "connections",
-        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: \"Alpha server\"\n",
+        "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: \"Alpha server\"\n",
     );
 
     // Provide the value for the missing user variable via stdin.
@@ -1945,7 +1945,7 @@ fn ssh_config_install_missing_user_variable_prompts_and_generates_correct_host_b
 
     env.write_user_config(
         "connections",
-        "connections:\n  conn-a:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth: password\n    description: A\n  conn-b:\n    host: 10.0.0.2\n    user: \"${t1user}\"\n    auth: password\n    description: B\n",
+        "connections:\n  conn-a:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: A\n  conn-b:\n    host: 10.0.0.2\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: B\n",
     );
 
     // Both connections share the same ${t1user} key — should prompt only once.


### PR DESCRIPTION
## Summary
- **Breaking change:** `auth` is now a YAML mapping node with `type`, `key`, and `cmd` subfields instead of a flat string with a sibling `key` field
- `Auth` enum with `Key { key, cmd }` and `Password` variants using serde internally-tagged serialization
- Convenience methods `type_label()`, `key()`, `cmd()` on `Auth` for ergonomic access
- `cmd` field is parsed and stored only — no execution logic in this release
- All commands updated: `list`, `show`, `connect`, `ssh-config`, `add`, `install`
- All unit tests (315), functional tests (58), example configs, and CLAUDE.md updated

## Test plan
- [x] `make test` passes (315 unit + 58 functional)
- [x] `make lint` passes (fmt + clippy clean)
- [ ] Manual: verify `yconn show` displays Auth, Key, Cmd fields correctly
- [ ] Manual: verify `yconn connections add` wizard emits nested auth block

🤖 Generated with [Claude Code](https://claude.com/claude-code)