### PR TITLE
keys setup creates the auth.key parent directory before spawning the shell command

### DIFF
--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -528,6 +528,41 @@ mod tests {
         assert_eq!(contents, "hello");
     }
 
+    #[test]
+    fn test_run_setup_iterate_all_creates_parent_per_connection() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        // Two connections, each with `auth.key` under its own non-existent
+        // parent directory. Iterate-all must create both parents and produce
+        // both key files.
+        let alpha_parent = root.path().join("alpha-parent");
+        let beta_parent = root.path().join("beta-parent");
+        let alpha_key = alpha_parent.join("alpha_key");
+        let beta_key = beta_parent.join("beta_key");
+
+        assert!(!alpha_parent.exists());
+        assert!(!beta_parent.exists());
+
+        let cfg_yaml = format!(
+            "connections:\n  alpha:\n    host: 1.1.1.1\n    user: u\n    auth:\n      type: key\n      key: {a}\n      generate_key: \"printf %s a > ${{key}}\"\n    description: a\n  beta:\n    host: 2.2.2.2\n    user: u\n    auth:\n      type: key\n      key: {b}\n      generate_key: \"printf %s b > ${{key}}\"\n    description: b\n",
+            a = alpha_key.display(),
+            b = beta_key.display(),
+        );
+        write_yaml(&yconn, "connections.yaml", &cfg_yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        run_setup(&cfg, &no_color(), None).unwrap();
+
+        assert!(alpha_parent.is_dir(), "alpha parent must be created");
+        assert!(beta_parent.is_dir(), "beta parent must be created");
+        assert_eq!(fs::read_to_string(&alpha_key).unwrap(), "a");
+        assert_eq!(fs::read_to_string(&beta_key).unwrap(), "b");
+    }
+
     // ── expand_tilde ──────────────────────────────────────────────────────────
 
     #[test]

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -563,6 +563,43 @@ mod tests {
         assert_eq!(fs::read_to_string(&beta_key).unwrap(), "b");
     }
 
+    #[test]
+    fn test_run_setup_named_uncreatable_parent_returns_error_and_does_not_spawn() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        // A regular file occupies what would otherwise be a parent directory
+        // component, so create_dir_all cannot create the parent for the key.
+        let blocker = root.path().join("blocker");
+        fs::write(&blocker, "i am a file, not a directory").unwrap();
+        let key_path = blocker.join("subdir").join("new_key");
+
+        // Sentinel file the shell command would touch if it ran. Asserting
+        // its absence proves the command was NOT spawned.
+        let sentinel = root.path().join("sentinel");
+        let cfg_yaml = format!(
+            "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: {key}\n      generate_key: \"touch {sentinel}\"\n    description: srv\n",
+            key = key_path.display(),
+            sentinel = sentinel.display(),
+        );
+        write_yaml(&yconn, "connections.yaml", &cfg_yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let err = run_setup(&cfg, &no_color(), Some("srv")).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to create parent directory"),
+            "error must surface a clear parent-dir failure, got: {msg}"
+        );
+        assert!(
+            !sentinel.exists(),
+            "shell command must not be spawned when parent-dir creation fails"
+        );
+    }
+
     // ── expand_tilde ──────────────────────────────────────────────────────────
 
     #[test]

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -600,6 +600,49 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_run_setup_iterate_all_uncreatable_parent_reports_and_continues() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        // alpha's parent path component is an existing file → un-creatable.
+        let blocker = root.path().join("blocker");
+        fs::write(&blocker, "regular file").unwrap();
+        let alpha_key = blocker.join("subdir").join("alpha_key");
+
+        // beta's parent does not exist but is creatable; success expected.
+        let beta_parent = root.path().join("beta-parent");
+        let beta_key = beta_parent.join("beta_key");
+
+        let cfg_yaml = format!(
+            "connections:\n  alpha:\n    host: 1.1.1.1\n    user: u\n    auth:\n      type: key\n      key: {a}\n      generate_key: \"echo unreachable > ${{key}}\"\n    description: a\n  beta:\n    host: 2.2.2.2\n    user: u\n    auth:\n      type: key\n      key: {b}\n      generate_key: \"printf %s done > ${{key}}\"\n    description: b\n",
+            a = alpha_key.display(),
+            b = beta_key.display(),
+        );
+        write_yaml(&yconn, "connections.yaml", &cfg_yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        // Iterate-all returns Ok; alpha's failure is reported via the
+        // renderer's error channel, beta still succeeds.
+        run_setup(&cfg, &no_color(), None).unwrap();
+
+        assert!(
+            beta_parent.is_dir(),
+            "beta's parent must be created despite alpha's failure"
+        );
+        assert_eq!(
+            fs::read_to_string(&beta_key).expect("beta key must be written"),
+            "done"
+        );
+        assert!(
+            !alpha_key.exists(),
+            "alpha key must not be created when its parent could not be"
+        );
+    }
+
     // ── expand_tilde ──────────────────────────────────────────────────────────
 
     #[test]

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -10,6 +10,7 @@
 // printing the command that was run and confirmation that the key was
 // written.
 
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -141,6 +142,18 @@ fn process_connection(conn: &Connection, renderer: &Renderer) -> Result<()> {
         // Should never happen: caller guarantees generate_key is set.
         bail!("connection '{}' has no generate_key configured", conn.name);
     };
+
+    if let Some(parent) = expanded_path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent).map_err(|e| {
+                anyhow!(
+                    "failed to create parent directory {} for {}: {e}",
+                    parent.display(),
+                    conn.name
+                )
+            })?;
+        }
+    }
 
     renderer.print_line(&conn.name);
     renderer.print_line(&expanded_cmd);
@@ -477,6 +490,42 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
         list(&cfg, &no_color()).unwrap();
+    }
+
+    // ── parent-directory creation ────────────────────────────────────────────
+
+    #[test]
+    fn test_run_setup_named_creates_missing_parent_directory() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+
+        // Target key path nested under a parent that does not exist yet.
+        let parent = root.path().join("nested").join("dir");
+        let key_path = parent.join("new_key");
+        assert!(
+            !parent.exists(),
+            "test precondition: parent dir must not exist"
+        );
+
+        let cfg_yaml = format!(
+            "connections:\n  srv:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: key\n      key: {}\n      generate_key: \"printf %s hello > ${{key}}\"\n    description: srv\n",
+            key_path.display()
+        );
+        write_yaml(&yconn, "connections.yaml", &cfg_yaml);
+
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        run_setup(&cfg, &no_color(), Some("srv")).unwrap();
+
+        assert!(
+            parent.is_dir(),
+            "parent directory must be created before the shell command runs"
+        );
+        let contents = fs::read_to_string(&key_path)
+            .expect("key file must be written into the newly-created parent");
+        assert_eq!(contents, "hello");
     }
 
     // ── expand_tilde ──────────────────────────────────────────────────────────

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2338,6 +2338,102 @@ fn keys_setup_named_without_generate_key_fails() {
     );
 }
 
+/// `yconn keys setup <name>` end-to-end against a key path whose parent does
+/// not exist on disk: the parent directory is created before the shell command
+/// runs, the key file is written, and no extra output line appears compared to
+/// the pre-existing-parent case (criterion 5: a pre-existing parent produces
+/// no extra output line).
+#[test]
+fn keys_setup_named_creates_missing_parent_and_emits_no_extra_output() {
+    // Run 1: parent does not exist — must be created on demand.
+    let env_missing = TestEnv::new();
+    let missing_parent = env_missing.cwd.path().join("nested").join("parent");
+    let missing_key = missing_parent.join("generated_key");
+    let yaml_missing = format!(
+        concat!(
+            "connections:\n",
+            "  gen-conn:\n",
+            "    host: 10.0.0.1\n",
+            "    user: deploy\n",
+            "    auth:\n",
+            "      type: key\n",
+            "      key: {key_path}\n",
+            "      generate_key: \"printf %s hello > ${{key}}\"\n",
+            "    description: Has gen key\n",
+        ),
+        key_path = missing_key.display(),
+    );
+    env_missing.write_user_config("connections", &yaml_missing);
+
+    assert!(
+        !missing_parent.exists(),
+        "test precondition: parent dir must not exist"
+    );
+
+    let out_missing = env_missing.run(&["keys", "setup", "gen-conn"]);
+    TestEnv::assert_ok(&out_missing);
+
+    assert!(
+        missing_parent.is_dir(),
+        "parent directory must be created end-to-end"
+    );
+    assert_eq!(
+        fs::read_to_string(&missing_key).expect("key file must be written"),
+        "hello"
+    );
+
+    let stdout_missing = String::from_utf8_lossy(&out_missing.stdout);
+
+    // Run 2: parent already exists — the same connection setup with the
+    // parent pre-created. Output must match the missing-parent run line-for-
+    // line, proving no extra "creating directory" notice was printed in
+    // either case.
+    let env_present = TestEnv::new();
+    let present_parent = env_present.cwd.path().join("nested").join("parent");
+    let present_key = present_parent.join("generated_key");
+    fs::create_dir_all(&present_parent).unwrap();
+
+    let yaml_present = format!(
+        concat!(
+            "connections:\n",
+            "  gen-conn:\n",
+            "    host: 10.0.0.1\n",
+            "    user: deploy\n",
+            "    auth:\n",
+            "      type: key\n",
+            "      key: {key_path}\n",
+            "      generate_key: \"printf %s hello > ${{key}}\"\n",
+            "    description: Has gen key\n",
+        ),
+        key_path = present_key.display(),
+    );
+    env_present.write_user_config("connections", &yaml_present);
+
+    let out_present = env_present.run(&["keys", "setup", "gen-conn"]);
+    TestEnv::assert_ok(&out_present);
+
+    let stdout_present = String::from_utf8_lossy(&out_present.stdout);
+
+    // Strip the path prefix from each stdout (the only thing that differs
+    // between the two runs is the absolute key path embedded in the
+    // expanded command and "Key written to:" line) so we can compare the
+    // structural output line-for-line.
+    let normalize = |s: &str, key_path: &std::path::Path| -> Vec<String> {
+        let needle = key_path.display().to_string();
+        s.lines().map(|l| l.replace(&needle, "<KEY>")).collect()
+    };
+
+    let lines_missing = normalize(&stdout_missing, &missing_key);
+    let lines_present = normalize(&stdout_present, &present_key);
+
+    assert_eq!(
+        lines_missing, lines_present,
+        "pre-existing parent must produce no extra output line; \
+         missing-parent stdout was: {stdout_missing:?}, \
+         pre-existing-parent stdout was: {stdout_present:?}",
+    );
+}
+
 // ─── End-to-end golden-path harness ──────────────────────────────────────────
 //
 // The end-to-end harness exercises every file-producing `yconn` subcommand


### PR DESCRIPTION
Closes #84

## Summary

`yconn keys setup` now creates the parent directory of `auth.key` on
demand (via `fs::create_dir_all`) before spawning the configured
`generate_key` shell command. Both the named form
(`yconn keys setup <name>`) and the iterate-all form create parents
when needed; an existing parent is silently reused with no extra
output line.

A failure to create the parent inherits the existing strict / lenient
contract:

- Named form — non-zero exit; the shell command is not spawned.
- Iterate-all form — the failure is reported through the renderer's
  error channel and the loop continues with remaining connections.

## Acceptance criteria

- [x] `yconn keys setup <name>` creates the missing parent directory
  before invoking the configured shell command — covered by
  `feat(keys): create auth.key parent directory in named setup form`.
- [x] `yconn keys setup` (iterate-all) creates parents for each
  connection — covered by
  `test(keys): cover iterate-all parent-dir creation across connections`.
- [x] Named form against an un-creatable parent returns non-zero,
  does not spawn the shell command, surfaces a clear error — covered
  by `test(keys): pin un-creatable-parent named-form error semantics`.
- [x] Iterate-all with one un-creatable parent reports and continues
  — covered by
  `test(keys): pin iterate-all un-creatable-parent reports-and-continues semantics`.
- [x] Pre-existing parent produces no extra output line — covered by
  `test(keys): pin no-extra-output and end-to-end parent-creation contract`.
- [x] Unit tests cover the named, iterate-all, and un-creatable-parent
  paths.
- [x] Functional `TestEnv` test drives `keys setup <name>` end-to-end
  against a key path whose parent does not exist on disk.

## Test plan

- [x] `make test` — 355 unit + 77 functional tests pass.
- [x] `make lint` — `cargo fmt --check` + `cargo clippy -- -D warnings`
  pass cleanly.

## Merge note

Per repo convention (`.claude/CLAUDE.md`), squash-merge this PR.