### PR TITLE
Expand ${user} (alongside ${key}) wherever rendered generate_key is surfaced

### DIFF
--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -57,7 +57,10 @@ pub(crate) fn build_key_rows(cfg: &LoadedConfig) -> Vec<KeyRow> {
             // generate_key field) — skip defensively.
             continue;
         };
-        let generate_key = conn.auth.generate_key_expanded().unwrap_or_default();
+        let generate_key = conn
+            .auth
+            .generate_key_rendered(&conn.user)
+            .unwrap_or_default();
         rows.push(KeyRow {
             name: conn.name.clone(),
             key: key_path.to_string(),
@@ -271,6 +274,26 @@ mod tests {
         let cfg = load(cwd.path(), None, empty.path());
         let rows = build_key_rows(&cfg);
         assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn test_build_key_rows_expands_user_and_key_placeholders() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "connections:\n  bastion:\n    host: 10.0.0.1\n    user: ec2-user\n    auth:\n      type: key\n      key: ~/.ssh/bastion_key\n      generate_key: \"vault read ssh/${user} > ${key}\"\n    description: Bastion\n",
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+        let rows = build_key_rows(&cfg);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].generate_key, "vault read ssh/ec2-user > ~/.ssh/bastion_key",
+            "GENERATE_KEY column must expand both ${{user}} and ${{key}}"
+        );
     }
 
     #[test]

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -5,8 +5,15 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-use crate::config::{Auth, LoadedConfig};
+use crate::config::{Auth, Connection, LoadedConfig};
 use crate::display::{ConnectionDetail, Renderer};
+
+/// Render `generate_key` for a connection with both `${key}` and `${user}`
+/// placeholders expanded in a single pass. Returns `None` when the connection
+/// has no `generate_key` configured.
+fn render_generate_key(conn: &Connection) -> Option<String> {
+    conn.auth.generate_key_rendered(&conn.user)
+}
 
 // ─── Dump serialisation types ─────────────────────────────────────────────────
 
@@ -143,7 +150,7 @@ pub fn run(cfg: &LoadedConfig, renderer: &Renderer, name: &str) -> Result<()> {
         port: conn.port,
         auth: conn.auth.type_label().to_string(),
         key: conn.auth.key().map(str::to_string),
-        generate_key: conn.auth.generate_key_expanded(),
+        generate_key: render_generate_key(&conn),
         description: conn.description.clone(),
         link: conn.link.clone(),
         source_label: conn.layer.label().to_string(),
@@ -439,6 +446,55 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), Some(user.path()), empty.path());
         run(&cfg, &no_color(), "db").unwrap();
+    }
+
+    /// Showing a connection whose `auth.generate_key` contains both
+    /// `${user}` and `${key}` must populate `ConnectionDetail.generate_key`
+    /// with both placeholders expanded — the user-facing show output must
+    /// not leak either raw token.
+    #[test]
+    fn test_show_generate_key_expands_user_and_key_placeholders() {
+        use crate::display::ConnectionDetail;
+
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "connections:\n  bastion:\n    host: 10.0.0.1\n    user: ec2-user\n    auth:\n      type: key\n      key: ~/.ssh/foo\n      generate_key: \"vault read -field=private_key secret/users/${user} > ${key}\"\n    description: Bastion\n",
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+
+        let conn = cfg.find_with_wildcard("bastion").unwrap();
+        let detail = ConnectionDetail {
+            name: conn.name.clone(),
+            host: conn.host.clone(),
+            user: conn.user.clone(),
+            port: conn.port,
+            auth: conn.auth.type_label().to_string(),
+            key: conn.auth.key().map(str::to_string),
+            generate_key: render_generate_key(&conn),
+            description: conn.description.clone(),
+            link: conn.link.clone(),
+            source_label: conn.layer.label().to_string(),
+            source_path: conn.source_path.display().to_string(),
+        };
+
+        let rendered = detail.generate_key.as_deref().unwrap();
+        assert_eq!(
+            rendered, "vault read -field=private_key secret/users/ec2-user > ~/.ssh/foo",
+            "expected both ${{user}} and ${{key}} expanded in show output"
+        );
+        assert!(
+            !rendered.contains("${user}"),
+            "expected no raw ${{user}} token in generate_key: {rendered}"
+        );
+        assert!(
+            !rendered.contains("${key}"),
+            "expected no raw ${{key}} token in generate_key: {rendered}"
+        );
     }
 
     /// Showing a connection whose `auth.generate_key` contains `${key}` must

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -448,6 +448,32 @@ mod tests {
         run(&cfg, &no_color(), "db").unwrap();
     }
 
+    /// `yconn show --dump` emits the raw on-disk `generate_key` value
+    /// verbatim — both `${key}` and `${user}` must be preserved in the YAML
+    /// output (no rendering applied at the dump layer).
+    #[test]
+    fn test_dump_preserves_raw_user_and_key_placeholders() {
+        let root = TempDir::new().unwrap();
+        let yconn = root.path().join(".yconn");
+        fs::create_dir_all(&yconn).unwrap();
+        write_yaml(
+            &yconn,
+            "connections.yaml",
+            "connections:\n  bastion:\n    host: 10.0.0.1\n    user: ec2-user\n    auth:\n      type: key\n      key: ~/.ssh/foo\n      generate_key: \"vault read ssh/${user} > ${key}\"\n    description: Bastion\n",
+        );
+        let empty = TempDir::new().unwrap();
+        let cfg = load(root.path(), None, empty.path());
+        let yaml = build_dump_yaml(&cfg).unwrap();
+        assert!(
+            yaml.contains("vault read ssh/${user} > ${key}"),
+            "dump output must preserve raw ${{user}} and ${{key}} placeholders verbatim, got:\n{yaml}"
+        );
+        assert!(
+            !yaml.contains("ec2-user > ~/.ssh/foo"),
+            "dump output must not expand placeholders, got:\n{yaml}"
+        );
+    }
+
     /// Showing a connection whose `auth.generate_key` contains both
     /// `${user}` and `${key}` must populate `ConnectionDetail.generate_key`
     /// with both placeholders expanded — the user-facing show output must

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1198,6 +1198,66 @@ mod tests {
         );
     }
 
+    /// Single-pass: a `${user}` substitution that yields literal `${key}`
+    /// text MUST NOT be expanded again in the same render. The output keeps
+    /// the substituted `${key}` token verbatim.
+    #[test]
+    fn test_generate_key_rendered_single_pass_user_value_containing_key_token() {
+        let auth = Auth::Key {
+            key: "/secret/path".to_string(),
+            generate_key: Some("echo ${user}".to_string()),
+        };
+        // `user` value is the literal text "${key}" — it must appear in the
+        // output verbatim, not expand to "/secret/path".
+        assert_eq!(
+            auth.generate_key_rendered("${key}").as_deref(),
+            Some("echo ${key}"),
+            "substituted text must not be rescanned"
+        );
+    }
+
+    /// Single-pass, opposite order: a `${key}` substitution that yields
+    /// literal `${user}` text MUST NOT be expanded again. The output keeps
+    /// the substituted `${user}` token verbatim.
+    #[test]
+    fn test_generate_key_rendered_single_pass_key_value_containing_user_token() {
+        let auth = Auth::Key {
+            key: "${user}".to_string(),
+            generate_key: Some("write ${key}".to_string()),
+        };
+        assert_eq!(
+            auth.generate_key_rendered("alice").as_deref(),
+            Some("write ${user}"),
+            "substituted text must not be rescanned (opposite order)"
+        );
+    }
+
+    /// A generate_key value with no placeholders is rendered verbatim.
+    #[test]
+    fn test_generate_key_rendered_without_placeholders_returns_verbatim() {
+        let auth = Auth::Key {
+            key: "~/.ssh/foo".to_string(),
+            generate_key: Some("vault read ssh/foo".to_string()),
+        };
+        assert_eq!(
+            auth.generate_key_rendered("alice").as_deref(),
+            Some("vault read ssh/foo")
+        );
+    }
+
+    /// The raw `Auth::generate_key()` accessor must be unaffected by
+    /// rendering — the on-disk source of truth is preserved.
+    #[test]
+    fn test_generate_key_raw_accessor_unchanged_after_rendering() {
+        let raw = "vault read ssh/${user} > ${key}";
+        let auth = Auth::Key {
+            key: "~/.ssh/foo".to_string(),
+            generate_key: Some(raw.to_string()),
+        };
+        let _ = auth.generate_key_rendered("alice");
+        assert_eq!(auth.generate_key(), Some(raw));
+    }
+
     // ── upward walk ───────────────────────────────────────────────────────────
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -151,6 +151,58 @@ impl Auth {
         let key_value = self.key().unwrap_or("");
         Some(raw.replace("${key}", key_value))
     }
+
+    /// Return `generate_key` with both `${key}` and `${user}` expanded in a
+    /// single pass.
+    ///
+    /// Single-pass means substituted text is never re-scanned: if a
+    /// substitution introduces text that itself looks like a placeholder
+    /// (e.g. a `user` value of `${key}`), it is left in the output verbatim.
+    ///
+    /// Unknown `${...}` tokens are passed through unchanged.
+    /// `${key}` expands to the value of [`Auth::key`] (empty string when
+    /// absent). The raw enum data is not mutated; this is a view.
+    pub fn generate_key_rendered(&self, user: &str) -> Option<String> {
+        let raw = self.generate_key()?;
+        let key_value = self.key().unwrap_or("");
+        Some(render_placeholders(raw, key_value, user))
+    }
+}
+
+/// Single-pass placeholder expander. Walks `input` left-to-right and replaces
+/// each occurrence of `${key}` with `key_value` and `${user}` with `user_value`.
+/// Substituted text is appended directly to the output and is not rescanned,
+/// so a user value containing `${key}` is preserved verbatim.
+fn render_placeholders(input: &str, key_value: &str, user_value: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            if let Some(end) = input[i + 2..].find('}') {
+                let token = &input[i + 2..i + 2 + end];
+                match token {
+                    "key" => {
+                        out.push_str(key_value);
+                        i += 2 + end + 1;
+                        continue;
+                    }
+                    "user" => {
+                        out.push_str(user_value);
+                        i += 2 + end + 1;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        // Push the next char as-is. Use char_indices semantics to keep utf-8
+        // intact even though placeholders are ASCII-only.
+        let ch = input[i..].chars().next().expect("non-empty remainder");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
 }
 
 fn default_port() -> u16 {
@@ -1129,6 +1181,21 @@ mod tests {
             generate_key: Some("vault read ssh/foo > ${key}".to_string()),
         };
         assert_eq!(auth.generate_key(), Some("vault read ssh/foo > ${key}"));
+    }
+
+    // ── Auth::generate_key_rendered (issue #83) ─────────────────────────────
+
+    /// Both `${key}` and `${user}` are expanded together in a single render.
+    #[test]
+    fn test_generate_key_rendered_expands_both_placeholders() {
+        let auth = Auth::Key {
+            key: "~/.ssh/foo".to_string(),
+            generate_key: Some("vault read ssh/${user} > ${key}".to_string()),
+        };
+        assert_eq!(
+            auth.generate_key_rendered("alice").as_deref(),
+            Some("vault read ssh/alice > ~/.ssh/foo")
+        );
     }
 
     // ── upward walk ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #83

## Summary

Expands the `${user}` placeholder (alongside the existing `${key}`)
wherever a connection's `generate_key` value is rendered to the user.
Both `yconn show <name>` (without `--dump`) and `yconn keys list` now
render `${user}` substituted with the connection's `user` field, in a
single left-to-right expansion pass that handles either placeholder in
any order. The raw on-disk value remains the source of truth — `yconn
show <name> --dump` still emits `generate_key` exactly as written in
the config file.

## Acceptance criteria coverage

- **`yconn show` (non-`--dump`) renders both `${key}` and `${user}` expanded** — `feat(show): expand both ${key} and ${user} placeholders in show output` (1f966f6) wires `ConnectionDetail.generate_key` through `Auth::generate_key_rendered`. Pinned by `test_show_generate_key_expands_user_and_key_placeholders`.
- **`yconn keys list` `GENERATE_KEY` column expanded** — `feat(keys): expand ${user} alongside ${key} in keys list output` (4bb513a) updates `build_key_rows` to use the new renderer. Pinned by `test_build_key_rows_expands_user_and_key_placeholders`.
- **`yconn show --dump` preserves raw, unexpanded value verbatim** — `test(show): assert dump preserves raw ${user} and ${key} verbatim` (36c464f) adds `test_dump_preserves_raw_user_and_key_placeholders` confirming serde dump path is untouched by the new renderer.
- **Single-pass expansion (substituted text not rescanned)** — `feat(config): expand both ${key} and ${user} placeholders in generate_key` (f92d7c9) introduces `Auth::generate_key_rendered` backed by a left-to-right walker that appends substituted text without rescanning. `test(config): pin single-pass and verbatim render semantics for generate_key` (375975b) covers both orders via `test_generate_key_rendered_single_pass_user_value_containing_key_token` and `test_generate_key_rendered_single_pass_key_value_containing_user_token`.
- **No-placeholder verbatim** — `test_generate_key_rendered_without_placeholders_returns_verbatim` (375975b).
- **Unit tests cover both placeholders together, either-order single-pass, no-placeholder verbatim, raw accessor unchanged** — covered by the five tests added in 375975b plus the kick-off test `test_generate_key_rendered_expands_both_placeholders` in f92d7c9. Raw accessor stability is pinned by `test_generate_key_raw_accessor_unchanged_after_rendering`.

## Test plan

- [x] `make test` (76 tests, all passing)
- [x] `make lint` clean (`cargo fmt --check` and `cargo clippy -- -D warnings`)

Per repo convention, please **squash-merge** this PR.