### PR TITLE
Fix process_connection to expand ${user} in generate_key commands

### DIFF
--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -141,7 +141,7 @@ fn process_connection(conn: &Connection, renderer: &Renderer) -> Result<()> {
         return Ok(());
     }
 
-    let Some(expanded_cmd) = conn.auth.generate_key_expanded() else {
+    let Some(expanded_cmd) = conn.auth.generate_key_rendered(&conn.user) else {
         // Should never happen: caller guarantees generate_key is set.
         bail!("connection '{}' has no generate_key configured", conn.name);
     };

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2564,6 +2564,46 @@ fn keys_setup_named_creates_missing_parent_and_emits_no_extra_output() {
     );
 }
 
+/// `yconn keys setup <name>` with `generate_key` containing `${user}` must
+/// expand the placeholder to the connection's user value before executing.
+#[test]
+fn keys_setup_expands_user_placeholder_in_generate_key() {
+    let env = TestEnv::new();
+
+    let key_path = env.cwd.path().join("generated_key");
+    let key_path_str = key_path.to_string_lossy();
+
+    let yaml = format!(
+        concat!(
+            "connections:\n",
+            "  user-expansion:\n",
+            "    host: 10.0.0.1\n",
+            "    user: ec2-user\n",
+            "    auth:\n",
+            "      type: key\n",
+            "      key: {key_path}\n",
+            "      generate_key: \"printf %s ${{user}} > ${{key}}\"\n",
+            "    description: Tests user placeholder expansion\n",
+        ),
+        key_path = key_path_str,
+    );
+    env.write_user_config("connections", &yaml);
+
+    // Sanity: file does not exist yet.
+    assert!(!key_path.exists(), "key file must not exist before setup");
+
+    // Run keys setup for the connection with ${user} in generate_key.
+    let out = env.run(&["keys", "setup", "user-expansion"]);
+    TestEnv::assert_ok(&out);
+
+    // The file should be created with content equal to the connection's user value.
+    let contents = fs::read_to_string(&key_path).expect("key file must be created by setup");
+    assert_eq!(
+        contents, "ec2-user",
+        "key file content must be the expanded user value"
+    );
+}
+
 // ─── End-to-end golden-path harness ──────────────────────────────────────────
 //
 // The end-to-end harness exercises every file-producing `yconn` subcommand


### PR DESCRIPTION
## Summary

Fix `process_connection` in `src/commands/keys.rs` to use `generate_key_rendered(&conn.user)` instead of `generate_key_expanded()`, enabling proper expansion of both `${key}` and `${user}` placeholders in shell commands executed via `yconn keys setup`.

## Changes

- **Fix process_connection to expand ${user}:** Changed line 144 in `src/commands/keys.rs` from `conn.auth.generate_key_expanded()` to `conn.auth.generate_key_rendered(&conn.user)` to properly expand both `${key}` and `${user}` placeholders before executing the shell command.

- **Add functional test:** New test `keys_setup_expands_user_placeholder_in_generate_key` in `tests/functional.rs` verifies that a connection with `generate_key: "printf %s ${user} > ${key}"` and `user: ec2-user` produces a key file with content `ec2-user`.

- **Backward compatibility:** All existing tests continue to pass, confirming that `${key}` expansion still works correctly.

## Test plan

- [x] All 365 unit tests pass
- [x] All 80 functional tests pass
- [x] New functional test exercises the ${user} placeholder expansion
- [x] Existing keys_setup tests verify ${key} expansion still works
- [x] No lint errors (cargo clippy, cargo fmt)

Please squash merge when ready.

Closes #93

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>