### PR TITLE
Normalize range-pattern Host lines in finalise_block

### DIFF
--- a/src/commands/ssh_config.rs
+++ b/src/commands/ssh_config.rs
@@ -230,7 +230,7 @@ fn finalise_block(lines: &[&str]) -> Option<HostBlock> {
         let rest = l.strip_prefix("Host ")?;
         // Ensure it is exactly one token (no embedded spaces).
         if !rest.is_empty() && !rest.contains(' ') {
-            Some(rest.to_string())
+            Some(translate_name_for_ssh(rest))
         } else {
             None
         }
@@ -1428,5 +1428,45 @@ mod tests {
             host_blocks.contains("User bob"),
             "expected 'User bob' in Host block, got: {host_blocks}"
         );
+    }
+
+    // Criterion 1: Range pattern names should be normalized to globs
+    #[test]
+    fn test_finalise_block_normalizes_range_pattern() {
+        let lines = vec![
+            "# comment",
+            "Host dkcphdcvsbld[4..28]",
+            "    HostName example.com",
+        ];
+        let block = super::finalise_block(&lines);
+        assert!(block.is_some(), "finalise_block should succeed");
+        let block = block.unwrap();
+        assert_eq!(
+            block.ssh_host, "dkcphdcvsbld*",
+            "range pattern [4..28] should be normalized to glob *"
+        );
+    }
+
+    // Criterion 2: Literal names should remain unchanged
+    #[test]
+    fn test_finalise_block_keeps_literal_names_unchanged() {
+        let lines = vec!["# comment", "Host prod-web", "    HostName example.com"];
+        let block = super::finalise_block(&lines);
+        assert!(block.is_some(), "finalise_block should succeed");
+        let block = block.unwrap();
+        assert_eq!(
+            block.ssh_host, "prod-web",
+            "literal name should remain unchanged"
+        );
+    }
+
+    // Criterion 3: Glob names should remain unchanged
+    #[test]
+    fn test_finalise_block_keeps_glob_names_unchanged() {
+        let lines = vec!["# comment", "Host web-*", "    HostName example.com"];
+        let block = super::finalise_block(&lines);
+        assert!(block.is_some(), "finalise_block should succeed");
+        let block = block.unwrap();
+        assert_eq!(block.ssh_host, "web-*", "glob name should remain unchanged");
     }
 }


### PR DESCRIPTION
## Summary

Applies `translate_name_for_ssh` to the extracted Host token in `finalise_block` so that stale range-pattern Host blocks from an existing `~/.ssh/yconn-connections` file are normalized to their glob equivalents before merging with newly rendered blocks. This ensures blocks like `Host dkcphdcvsbld[4..28]` have their `ssh_host` key normalized to `dkcphdcvsbld*`, making the merge key symmetric with newly rendered blocks and enabling proper in-place replacement rather than preserving stale blocks.

## Test plan

- [x] Calling `finalise_block` with `"Host dkcphdcvsbld[4..28]"` returns `ssh_host = "dkcphdcvsbld*"`
- [x] `finalise_block` with literal name `"Host prod-web"` returns `ssh_host = "prod-web"` unchanged
- [x] `finalise_block` with glob name `"Host web-*"` returns `ssh_host = "web-*"` unchanged
- [x] All 377 unit tests pass
- [x] All 83 functional tests pass
- [x] No lint warnings

Closes #100

Use squash-merge to combine into main.

🤖 Generated with Claude Code