### PR TITLE
refactor(commands): rename user::show to user::list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,28 +270,28 @@ When `--verbose` is passed, the full `docker run` command is printed before exec
 
 | Command | Description |
 |---|---|
-| `yconn list` | List all connections across all layers |
+| `yconn connections list` | List all connections across all layers |
 | `yconn connect <name>` | Connect to a named host |
-| `yconn show <name>` | Show the resolved config for a connection (no secrets printed) |
-| `yconn add` | Interactive wizard to add a connection to a chosen layer |
-| `yconn edit <name>` | Open the connection's source config file in `$EDITOR` |
-| `yconn remove <name>` | Remove a connection (prompts for layer if ambiguous) |
-| `yconn init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
+| `yconn connections show <name>` | Show the resolved config for a connection (no secrets printed) |
+| `yconn connections add` | Interactive wizard to add a connection to a chosen layer |
+| `yconn connections edit <name>` | Open the connection's source config file in `$EDITOR` |
+| `yconn connections remove <name>` | Remove a connection (prompts for layer if ambiguous) |
+| `yconn connections init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
 | `yconn config` | Show which config files are active, their paths, and Docker status |
-| `yconn group list` | Show all groups found across all layers |
-| `yconn group use <n>` | Set the active group (persisted to `~/.config/yconn/session.yml`) |
-| `yconn group clear` | Remove `active_group` from `session.yml`, revert to default (`connections`) |
-| `yconn group current` | Print the active group name and resolved config file paths |
+| `yconn groups list` | Show all groups found across all layers |
+| `yconn groups use <n>` | Set the active group (persisted to `~/.config/yconn/session.yml`) |
+| `yconn groups clear` | Remove `active_group` from `session.yml`, revert to default (`connections`) |
+| `yconn groups current` | Print the active group name and resolved config file paths |
 
 Global flags:
 - `--layer system|user|project` — target a specific layer for `add`, `edit`, `remove`
-- `--all` — include shadowed entries in `yconn list`
+- `--all` — include shadowed entries in `yconn connections list`
 - `--no-color` — disable colored output
 - `--verbose` — print config loading decisions, merge resolution, and full Docker invocation
 
 ---
 
-## `yconn list` Output Format
+## `yconn connections list` Output Format
 
 Standard output (active connections only):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Groups are inline tags on individual connections. Each connection entry can carr
 `group:` field. All connections live in `connections.yaml` regardless of their group.
 
 The active group (set with `yconn groups use <name>`) acts as a filter: when a group is locked,
-`yconn list` shows only connections whose `group:` field matches. `yconn list --all` always
+`yconn connections list` shows only connections whose `group:` field matches. `yconn connections list --all` always
 shows all connections regardless of any lock.
 
 See `yconn groups --help` or [docs/examples.md](examples.md#inline-group-field-usage) for group
@@ -107,7 +107,7 @@ connections:
 | `auth` | yes | `key` or `password` |
 | `key` | if `auth: key` | Path to private key file. When using Docker, the path is resolved inside the container. |
 | `description` | yes | Human-readable description of the connection |
-| `group` | no | Inline group tag. Used to filter connections with `yconn groups use` or `yconn list --group`. |
+| `group` | no | Inline group tag. Used to filter connections with `yconn groups use` or `yconn connections list --group`. |
 | `link` | no | URL for further documentation (wiki, runbook, etc.) |
 
 ---
@@ -249,7 +249,7 @@ all generated Host blocks. `--skip-user` and `--user` are mutually exclusive.
 
 ```bash
 # List all user entries across all layers
-yconn users show
+yconn users list
 
 # Add a user entry interactively (defaults to user layer)
 yconn users add

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -55,7 +55,7 @@ connections:
 yconn connections init
 
 # List all connections
-yconn list
+yconn connections list
 
 # Show full details for a connection
 yconn connections show prod-web
@@ -128,14 +128,14 @@ connections:
 
 ```bash
 # List connections — prod-web shows from user layer (your override wins)
-yconn list
+yconn connections list
 
 # See where prod-web comes from
 yconn connections show prod-web
 # Source: user (/home/you/.config/yconn/connections.yaml)
 
 # See all entries including the shadowed team version
-yconn list --all
+yconn connections list --all
 # prod-web appears twice: user layer (active) and project layer (shadowed)
 
 # Connect using your overridden key
@@ -146,7 +146,7 @@ yconn connect prod-web
 
 - The user layer (`~/.config/yconn/`) takes higher priority than the project layer
   (`.yconn/`). Any connection defined in both layers will use the user-layer values.
-- The project layer entry for `prod-web` is still present — `yconn list --all` shows it
+- The project layer entry for `prod-web` is still present — `yconn connections list --all` shows it
   with a `[shadowed]` tag.
 - Unique connection names (like `dev-vm`) are simply merged in alongside project entries.
 
@@ -287,13 +287,13 @@ connections:
 yconn groups list
 
 # Show all connections (no group filter)
-yconn list
+yconn connections list
 
 # Switch to the work group — subsequent list/connect only shows work connections
 yconn groups use work
 
 # List only work connections
-yconn list
+yconn connections list
 
 # Connect to a work server
 yconn connect work-web
@@ -302,16 +302,16 @@ yconn connect work-web
 yconn groups use private
 
 # List only private connections
-yconn list
+yconn connections list
 
 # Connect to the home server
 yconn connect home-server
 
 # Show connections from a specific group without changing the active group
-yconn list --group work
+yconn connections list --group work
 
 # Show all connections regardless of active group
-yconn list --all
+yconn connections list --all
 
 # Check which group is currently active
 yconn groups current
@@ -328,7 +328,7 @@ yconn groups clear
   terminal sessions until changed.
 - Connections without a `group:` field are always shown when no group filter is active.
   When a group is locked, only tagged connections matching the group are shown.
-- `yconn list --all` always overrides any group filter and shows every connection.
+- `yconn connections list --all` always overrides any group filter and shows every connection.
 - `yconn groups use <name>` warns if no connections with that group value exist in any
   layer, but it still sets the group.
 
@@ -420,7 +420,7 @@ yconn connections show web-prod-01
 - Use `host: "${name}.corp.com"` to append a domain suffix to every matched input.
 - Use `host: "${name}"` or leave host blank/placeholder for bare-hostname behaviour.
 - Quote range-pattern YAML keys that contain `[`: `"app[1..20]"`.
-- Pattern entries appear in `yconn list` with their raw pattern name (e.g. `app[1..20]`)
+- Pattern entries appear in `yconn connections list` with their raw pattern name (e.g. `app[1..20]`)
   in the NAME column.
 - Same-pattern names across layers follow normal priority rules (higher layer wins) and
   do not trigger conflict detection.
@@ -487,7 +487,7 @@ directory and checks again.
 - All three conventions are recognised by the upward walk — you can mix conventions
   across different projects.
 - `yconn connections init` fails with a clear error if the target file already exists.
-- After running `yconn connections init`, edit the scaffolded file and run `yconn list` to verify.
+- After running `yconn connections init`, edit the scaffolded file and run `yconn connections list` to verify.
 
 ---
 
@@ -537,7 +537,7 @@ yconn connections show prod-web
 # User: ${testuser}   ← raw value, not expanded
 
 # List all user entries across all layers (with source and shadowing info)
-yconn users show
+yconn users list
 
 # Add a new user entry interactively (defaults to user layer)
 yconn users add

--- a/docs/man/yconn.1.md
+++ b/docs/man/yconn.1.md
@@ -193,7 +193,7 @@ keys to be pre-baked into an image rather than distributed to developer machines
 # OPTIONS
 
 **--all**
-: Include shadowed entries in the output of **yconn list**.
+: Include shadowed entries in the output of **yconn connections list**.
 
 **--verbose**
 : Print config loading decisions, merge resolution, and the full Docker
@@ -321,13 +321,13 @@ If present in the user layer, it is ignored with a warning.
 List connections from all layers:
 
 ```
-yconn list
+yconn connections list
 ```
 
 Filter connections by group:
 
 ```
-yconn list --group work
+yconn connections list --group work
 ```
 
 Connect to a host:
@@ -345,7 +345,7 @@ yconn connect web-prod-01
 Show all details for a connection (including shadowed):
 
 ```
-yconn list --all
+yconn connections list --all
 yconn connections show bastion
 ```
 
@@ -407,7 +407,7 @@ yconn keys setup bastion       # generate the key for a single connection
 Manage user key/value entries:
 
 ```
-yconn users show
+yconn users list
 yconn users add
 yconn users add --layer project
 yconn users edit testuser

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -64,7 +64,7 @@ pub(crate) fn run_impl(cwd: &std::path::Path, location: InitLocation) -> Result<
     set_private_permissions(&target)?;
 
     println!("Created {}", canonicalize_display(&target).display());
-    println!("Edit it to add connections, then run `yconn list` to verify.");
+    println!("Edit it to add connections, then run `yconn connections list` to verify.");
 
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,4 @@
-// Handler for `yconn list` — list all connections across all layers.
+// Handler for `yconn connections list` — list all connections across all layers.
 
 use std::collections::{HashMap, HashSet};
 
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(keys, vec!["user"]);
     }
 
-    // ─── Users table in yconn list tests ─────────────────────────────────────
+    // ─── Users table in yconn connections list tests ────────────────────────
 
     fn conn_yaml_with_user(name: &str, host: &str, user: &str) -> String {
         format!(

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -1,4 +1,4 @@
-// Handler for `yconn users show|add|edit` — manage the users: config section.
+// Handler for `yconn users list|add|edit` — manage the users: config section.
 
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -11,20 +11,20 @@ use crate::display::{Renderer, UserRow};
 
 // ─── Public entry points ──────────────────────────────────────────────────────
 
-/// `yconn users show` — list all user entries across layers with source and
+/// `yconn users list` — list all user entries across layers with source and
 /// shadowing info.
 ///
 /// When a `user` key is present in the merged `users:` map it appears as a
 /// normal row. When it is absent but `$USER` is set, a synthetic row with
 /// SOURCE `env (environment variable $USER)` is appended so the effective
 /// username is always visible.
-pub fn show(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
+pub fn list(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
     let rows = build_user_rows(cfg, std::env::var("USER").ok().as_deref());
     renderer.user_list(&rows);
     Ok(())
 }
 
-/// Build the [`UserRow`] vec for `yconn users show`.
+/// Build the [`UserRow`] vec for `yconn users list`.
 ///
 /// Converts `cfg.all_users` to rows, then — when no `user` key exists in
 /// `cfg.users` but `env_user` is `Some` — appends a synthetic env-var row.

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -7,7 +7,7 @@
 
 // ─── Input types ─────────────────────────────────────────────────────────────
 
-/// A row in the `yconn list` output table.
+/// A row in the `yconn connections list` output table.
 pub struct ConnectionRow {
     pub name: String,
     pub host: String,
@@ -60,7 +60,7 @@ pub struct ConfigStatus {
     pub docker: Option<DockerInfo>,
 }
 
-/// A row in the `yconn users show` output table.
+/// A row in the `yconn users list` output table.
 pub struct UserRow {
     pub key: String,
     pub value: String,
@@ -515,7 +515,7 @@ impl Renderer {
 
     // ── public API ────────────────────────────────────────────────────────────
 
-    /// Print the connection list table (`yconn list`).
+    /// Print the connection list table (`yconn connections list`).
     pub fn list(&self, rows: &[ConnectionRow]) {
         print!("{}", self.render_list(rows));
     }
@@ -530,7 +530,7 @@ impl Renderer {
         print!("{}", self.render_config_status(status));
     }
 
-    /// Print the user list table (`yconn users show`).
+    /// Print the user list table (`yconn users list`).
     ///
     /// Accepts a slice of [`UserRow`] so callers can inject synthetic rows
     /// (e.g. an env-var fallback for the `user` key).

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn main() -> Result<()> {
         Commands::Users { subcommand } => match subcommand {
             UserCommands::List => {
                 let cfg = load_and_warn(&renderer, verbose)?;
-                commands::user::show(&cfg, &renderer)
+                commands::user::list(&cfg, &renderer)
             }
             UserCommands::Add { layer, user_pairs } => commands::user::add(layer, user_pairs),
             UserCommands::Edit { key, layer } => {


### PR DESCRIPTION
## Summary

Rename the user command handler from `show` to `list` to align with the new CLI structure where `yconn users list` is the canonical name. All in-code doc comments and string references have been updated to use `yconn connections list` and `yconn users list` where applicable.

## Changes

1. **src/commands/user.rs**: `pub fn show(...)` renamed to `pub fn list(...)`; doc comments updated from "yconn users show" to "yconn users list"; file-level comment updated to reference "users list" instead of "users show"

2. **src/main.rs**: Call site updated from `commands::user::show(...)` to `commands::user::list(...)`

3. **src/commands/init.rs**: Hint string updated from "yconn list" to "yconn connections list"

4. **src/commands/list.rs**: Doc comment and test section banner updated to reference "yconn connections list"

5. **src/display/mod.rs**: All string literals in doc comments updated - "yconn list" → "yconn connections list" and "yconn users show" → "yconn users list"

## Test Status

All 93 tests pass with no warnings from cargo fmt or clippy (pre-existing warnings unrelated to this change).

Closes #112
Please squash-merge per repo convention.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>