### PR TITLE
refactor(commands): rename user::show to user::list

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -64,7 +64,7 @@ pub(crate) fn run_impl(cwd: &std::path::Path, location: InitLocation) -> Result<
     set_private_permissions(&target)?;
 
     println!("Created {}", canonicalize_display(&target).display());
-    println!("Edit it to add connections, then run `yconn list` to verify.");
+    println!("Edit it to add connections, then run `yconn connections list` to verify.");
 
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,4 @@
-// Handler for `yconn list` — list all connections across all layers.
+// Handler for `yconn connections list` — list all connections across all layers.
 
 use std::collections::{HashMap, HashSet};
 

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -1,4 +1,4 @@
-// Handler for `yconn users show|add|edit` — manage the users: config section.
+// Handler for `yconn users list|add|edit` — manage the users: config section.
 
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -11,20 +11,20 @@ use crate::display::{Renderer, UserRow};
 
 // ─── Public entry points ──────────────────────────────────────────────────────
 
-/// `yconn users show` — list all user entries across layers with source and
+/// `yconn users list` — list all user entries across layers with source and
 /// shadowing info.
 ///
 /// When a `user` key is present in the merged `users:` map it appears as a
 /// normal row. When it is absent but `$USER` is set, a synthetic row with
 /// SOURCE `env (environment variable $USER)` is appended so the effective
 /// username is always visible.
-pub fn show(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
+pub fn list(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
     let rows = build_user_rows(cfg, std::env::var("USER").ok().as_deref());
     renderer.user_list(&rows);
     Ok(())
 }
 
-/// Build the [`UserRow`] vec for `yconn users show`.
+/// Build the [`UserRow`] vec for `yconn users list`.
 ///
 /// Converts `cfg.all_users` to rows, then — when no `user` key exists in
 /// `cfg.users` but `env_user` is `Some` — appends a synthetic env-var row.

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -7,7 +7,7 @@
 
 // ─── Input types ─────────────────────────────────────────────────────────────
 
-/// A row in the `yconn list` output table.
+/// A row in the `yconn connections list` output table.
 pub struct ConnectionRow {
     pub name: String,
     pub host: String,
@@ -60,7 +60,7 @@ pub struct ConfigStatus {
     pub docker: Option<DockerInfo>,
 }
 
-/// A row in the `yconn users show` output table.
+/// A row in the `yconn users list` output table.
 pub struct UserRow {
     pub key: String,
     pub value: String,
@@ -515,7 +515,7 @@ impl Renderer {
 
     // ── public API ────────────────────────────────────────────────────────────
 
-    /// Print the connection list table (`yconn list`).
+    /// Print the connection list table (`yconn connections list`).
     pub fn list(&self, rows: &[ConnectionRow]) {
         print!("{}", self.render_list(rows));
     }
@@ -530,7 +530,7 @@ impl Renderer {
         print!("{}", self.render_config_status(status));
     }
 
-    /// Print the user list table (`yconn users show`).
+    /// Print the user list table (`yconn users list`).
     ///
     /// Accepts a slice of [`UserRow`] so callers can inject synthetic rows
     /// (e.g. an env-var fallback for the `user` key).

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn main() -> Result<()> {
         Commands::Users { subcommand } => match subcommand {
             UserCommands::List => {
                 let cfg = load_and_warn(&renderer, verbose)?;
-                commands::user::show(&cfg, &renderer)
+                commands::user::list(&cfg, &renderer)
             }
             UserCommands::Add { layer, user_pairs } => commands::user::add(layer, user_pairs),
             UserCommands::Edit { key, layer } => {


### PR DESCRIPTION
## Summary

Rename the public function `pub fn show` to `pub fn list` in `src/commands/user.rs`, update the call site in `src/main.rs`, and sweep all string literals and doc comments to reflect the new command names: `yconn connections list` and `yconn users list`.

## Details

- Renamed `pub fn show` to `pub fn list` in `src/commands/user.rs`
- Updated file-level comment to reference `users list|add|edit` instead of `users show|add|edit`
- Updated doc comments to reference `yconn users list` instead of `yconn users show`
- Updated the call site in `src/main.rs` from `commands::user::show(...)` to `commands::user::list(...)`
- Updated the hint string in `src/commands/init.rs` to reference `yconn connections list` instead of `yconn list`
- Updated the doc comment in `src/commands/list.rs` to reference `yconn connections list`
- Updated all four occurrences in `src/display/mod.rs`:
  - ConnectionRow doc comment: `yconn list` → `yconn connections list`
  - UserRow doc comment: `yconn users show` → `yconn users list`
  - list() method doc comment: `yconn list` → `yconn connections list`
  - user_list() method doc comment: `yconn users show` → `yconn users list`

All 93 tests pass. Code is formatted and clippy-clean.

Closes #112

Please squash-merge this PR.