### PR TITLE
Refactor Commands::Install CLI surface with selector flags

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -204,8 +204,8 @@ pub enum KeyCommands {
 
     /// Run the `generate_key` command for one connection (by name) or all
     /// qualifying connections (no argument)
-    Setup {
-        /// Name of the connection to set up. When omitted, iterates every
+    Install {
+        /// Name of the connection to install. When omitted, iterates every
         /// connection that has a `generate_key` configured.
         name: Option<String>,
     },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -143,6 +143,15 @@ pub enum Commands {
         /// Target layer to install connections into (user or system; project is not allowed)
         #[arg(long, value_name = "LAYER")]
         layer: Option<LayerArg>,
+        /// Install connections phase
+        #[arg(long)]
+        connections: bool,
+        /// Install keys phase
+        #[arg(long)]
+        keys: bool,
+        /// Install SSH config phase
+        #[arg(long)]
+        ssh_config: bool,
     },
 
     /// Audit and generate SSH keys via connection generate_key commands

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -17,9 +17,52 @@ use crate::config::{Layer, LoadedConfig, UserEntry};
 use super::add::{entry_exists, insert_connection, set_private_permissions};
 use super::user::write_user_entry;
 
+// ─── Selector types ───────────────────────────────────────────────────────────
+
+/// Resolved selectors for install phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct InstallSelectors {
+    pub connections: bool,
+    pub keys: bool,
+    pub ssh_config: bool,
+}
+
+/// Resolve selector flags using the default-to-all rule.
+///
+/// When none of the flags are provided, all phases are enabled.
+/// When one or more flags are provided, only the flagged phases are enabled.
+#[allow(dead_code)]
+pub fn resolve_selectors(connections: bool, keys: bool, ssh_config: bool) -> InstallSelectors {
+    if !connections && !keys && !ssh_config {
+        // No flags provided — enable all phases (default-to-all rule).
+        InstallSelectors {
+            connections: true,
+            keys: true,
+            ssh_config: true,
+        }
+    } else {
+        // One or more flags provided — use only those that are true.
+        InstallSelectors {
+            connections,
+            keys,
+            ssh_config,
+        }
+    }
+}
+
 // ─── Public entry point ───────────────────────────────────────────────────────
 
-pub fn run(cfg: &LoadedConfig, layer: Option<LayerArg>) -> Result<()> {
+pub fn run(
+    cfg: &LoadedConfig,
+    layer: Option<LayerArg>,
+    connections: bool,
+    keys: bool,
+    ssh_config: bool,
+) -> Result<()> {
+    // Resolve selector flags using the default-to-all rule.
+    let _selectors = resolve_selectors(connections, keys, ssh_config);
+
     // Reject --layer project: installing into the project layer is circular.
     if matches!(layer, Some(LayerArg::Project)) {
         bail!("--layer project is not allowed for 'install'; the project layer is the source");
@@ -826,5 +869,85 @@ mod tests {
         // Value should be written.
         let target = fs::read_to_string(&target_file).unwrap();
         assert!(target.contains("alice"), "prompted value must be written");
+    }
+
+    // ── resolve_selectors tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_selectors_no_flags_enables_all_phases() {
+        let selectors = resolve_selectors(false, false, false);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: true,
+                keys: true,
+                ssh_config: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_selectors_connections_only() {
+        let selectors = resolve_selectors(true, false, false);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: true,
+                keys: false,
+                ssh_config: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_selectors_keys_only() {
+        let selectors = resolve_selectors(false, true, false);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: false,
+                keys: true,
+                ssh_config: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_selectors_ssh_config_only() {
+        let selectors = resolve_selectors(false, false, true);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: false,
+                keys: false,
+                ssh_config: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_selectors_connections_and_keys() {
+        let selectors = resolve_selectors(true, true, false);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: true,
+                keys: true,
+                ssh_config: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_selectors_all_three_flags() {
+        let selectors = resolve_selectors(true, true, true);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: true,
+                keys: true,
+                ssh_config: true
+            }
+        );
     }
 }

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -1,11 +1,11 @@
 // src/commands/keys.rs
-// Handler for `yconn keys list|setup` — audit and generate SSH keys using
+// Handler for `yconn keys list|install` — audit and generate SSH keys using
 // connection `auth.generate_key` commands.
 //
 // `keys list` prints a table of every connection that has `generate_key`
 // configured. Connections without `generate_key` are omitted entirely.
 //
-// `keys setup` executes the `${key}`-expanded `generate_key` command for the
+// `keys install` executes the `${key}`-expanded `generate_key` command for the
 // named connection (or all qualifying connections when no name is supplied),
 // printing the command that was run and confirmation that the key was
 // written.
@@ -39,8 +39,8 @@ pub fn list(cfg: &LoadedConfig, renderer: &Renderer) -> Result<()> {
 /// - `name = None`: every connection is scanned; connections without
 ///   `generate_key` are silently skipped. A failure in one connection does
 ///   not abort the loop — subsequent connections are still processed.
-pub fn setup(cfg: &LoadedConfig, renderer: &Renderer, name: Option<&str>) -> Result<()> {
-    run_setup(cfg, renderer, name)
+pub fn install(cfg: &LoadedConfig, renderer: &Renderer, name: Option<&str>) -> Result<()> {
+    run_install(cfg, renderer, name)
 }
 
 /// Update (refresh) the SSH key by deleting the existing key file and
@@ -100,11 +100,11 @@ pub(crate) fn build_key_rows(cfg: &LoadedConfig) -> Vec<KeyRow> {
 /// supplied. The two forms have intentionally different error semantics:
 /// single-name is strict (missing `generate_key` aborts), iterate-all is
 /// lenient (missing `generate_key` is silently skipped).
-pub(crate) fn run_setup(cfg: &LoadedConfig, renderer: &Renderer, name: Option<&str>) -> Result<()> {
+pub(crate) fn run_install(cfg: &LoadedConfig, renderer: &Renderer, name: Option<&str>) -> Result<()> {
     match name {
-        Some(target) => run_setup_named(cfg, renderer, target),
+        Some(target) => run_install_named(cfg, renderer, target),
         None => {
-            run_setup_all(cfg, renderer);
+            run_install_all(cfg, renderer);
             Ok(())
         }
     }
@@ -112,7 +112,7 @@ pub(crate) fn run_setup(cfg: &LoadedConfig, renderer: &Renderer, name: Option<&s
 
 /// Strict single-connection form: missing `generate_key` or unknown name
 /// aborts non-zero.
-fn run_setup_named(cfg: &LoadedConfig, renderer: &Renderer, name: &str) -> Result<()> {
+fn run_install_named(cfg: &LoadedConfig, renderer: &Renderer, name: &str) -> Result<()> {
     let conn = cfg
         .find(name)
         .ok_or_else(|| anyhow!("unknown connection '{name}'"))?;
@@ -127,7 +127,7 @@ fn run_setup_named(cfg: &LoadedConfig, renderer: &Renderer, name: &str) -> Resul
 /// Lenient iterate-all form: silently skip connections without
 /// `generate_key`; continue past individual failures so one bad entry does
 /// not block the rest.
-fn run_setup_all(cfg: &LoadedConfig, renderer: &Renderer) {
+fn run_install_all(cfg: &LoadedConfig, renderer: &Renderer) {
     for conn in &cfg.connections {
         if conn.auth.generate_key().is_none() {
             continue;
@@ -307,7 +307,7 @@ fn process_connection(conn: &Connection, renderer: &Renderer) -> Result<()> {
 
     if !status.success() {
         let code = status.code().unwrap_or(-1);
-        bail!("keys setup {} failed (exit code {code})", conn.name);
+        bail!("keys install {} failed (exit code {code})", conn.name);
     }
 
     renderer.print_line(&format!("Key written to: {}", key_path));
@@ -465,10 +465,10 @@ mod tests {
         assert_eq!(rows[0].generate_key, "op read secret > ~/.ssh/github_key");
     }
 
-    // ── run_setup named connection — error semantics ─────────────────────────
+    // ── run_install named connection — error semantics ─────────────────────────
 
     #[test]
-    fn test_run_setup_named_without_generate_key_returns_error() {
+    fn test_run_install_named_without_generate_key_returns_error() {
         let root = TempDir::new().unwrap();
         let yconn = root.path().join(".yconn");
         fs::create_dir_all(&yconn).unwrap();
@@ -479,7 +479,7 @@ mod tests {
         );
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
-        let err = run_setup(&cfg, &no_color(), Some("srv")).unwrap_err();
+        let err = run_install(&cfg, &no_color(), Some("srv")).unwrap_err();
         assert!(
             err.to_string().contains("has no generate_key configured"),
             "error should mention missing generate_key, got: {err}"
@@ -487,11 +487,11 @@ mod tests {
     }
 
     #[test]
-    fn test_run_setup_unknown_name_returns_error() {
+    fn test_run_install_unknown_name_returns_error() {
         let cwd = TempDir::new().unwrap();
         let empty = TempDir::new().unwrap();
         let cfg = load(cwd.path(), None, empty.path());
-        let err = run_setup(&cfg, &no_color(), Some("nope")).unwrap_err();
+        let err = run_install(&cfg, &no_color(), Some("nope")).unwrap_err();
         assert!(
             err.to_string().contains("unknown connection"),
             "error should mention 'unknown connection', got: {err}"
@@ -503,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn test_run_setup_iterate_all_silently_skips_without_generate_key() {
+    fn test_run_install_iterate_all_silently_skips_without_generate_key() {
         let root = TempDir::new().unwrap();
         let yconn = root.path().join(".yconn");
         fs::create_dir_all(&yconn).unwrap();
@@ -517,7 +517,7 @@ mod tests {
         let cfg = load(root.path(), None, empty.path());
         // Iterate-all returns Ok() with no output and no error — nothing
         // qualifies, so there is nothing to do.
-        run_setup(&cfg, &no_color(), None).unwrap();
+        run_install(&cfg, &no_color(), None).unwrap();
     }
 
     // ── process_connection: key file already exists → skip ───────────────────
@@ -544,7 +544,7 @@ mod tests {
         // The command must NOT be executed (which would write "fail" over the
         // existing content); instead the function returns Ok and the original
         // contents remain.
-        run_setup(&cfg, &no_color(), Some("srv")).unwrap();
+        run_install(&cfg, &no_color(), Some("srv")).unwrap();
         let contents = fs::read_to_string(&existing_key).unwrap();
         assert_eq!(
             contents, "pretend key",
@@ -572,7 +572,7 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
 
-        run_setup(&cfg, &no_color(), Some("srv")).unwrap();
+        run_install(&cfg, &no_color(), Some("srv")).unwrap();
         let contents = fs::read_to_string(&key_path).unwrap();
         assert_eq!(contents, "hello");
     }
@@ -596,9 +596,9 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
 
-        let err = run_setup(&cfg, &no_color(), Some("srv")).unwrap_err();
+        let err = run_install(&cfg, &no_color(), Some("srv")).unwrap_err();
         assert!(
-            err.to_string().contains("keys setup srv failed"),
+            err.to_string().contains("keys install srv failed"),
             "error message should mention failure with exit code, got: {err}"
         );
     }
@@ -627,7 +627,7 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
 
-        run_setup(&cfg, &no_color(), None).unwrap();
+        run_install(&cfg, &no_color(), None).unwrap();
         let contents = fs::read_to_string(&ok_key).expect("beta key must be produced");
         assert_eq!(contents, "done");
         assert!(
@@ -656,7 +656,7 @@ mod tests {
     // ── parent-directory creation ────────────────────────────────────────────
 
     #[test]
-    fn test_run_setup_named_creates_missing_parent_directory() {
+    fn test_run_install_named_creates_missing_parent_directory() {
         let root = TempDir::new().unwrap();
         let yconn = root.path().join(".yconn");
         fs::create_dir_all(&yconn).unwrap();
@@ -678,7 +678,7 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
 
-        run_setup(&cfg, &no_color(), Some("srv")).unwrap();
+        run_install(&cfg, &no_color(), Some("srv")).unwrap();
 
         assert!(
             parent.is_dir(),
@@ -690,7 +690,7 @@ mod tests {
     }
 
     #[test]
-    fn test_run_setup_iterate_all_creates_parent_per_connection() {
+    fn test_run_install_iterate_all_creates_parent_per_connection() {
         let root = TempDir::new().unwrap();
         let yconn = root.path().join(".yconn");
         fs::create_dir_all(&yconn).unwrap();
@@ -716,7 +716,7 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
 
-        run_setup(&cfg, &no_color(), None).unwrap();
+        run_install(&cfg, &no_color(), None).unwrap();
 
         assert!(alpha_parent.is_dir(), "alpha parent must be created");
         assert!(beta_parent.is_dir(), "beta parent must be created");
@@ -725,7 +725,7 @@ mod tests {
     }
 
     #[test]
-    fn test_run_setup_named_uncreatable_parent_returns_error_and_does_not_spawn() {
+    fn test_run_install_named_uncreatable_parent_returns_error_and_does_not_spawn() {
         let root = TempDir::new().unwrap();
         let yconn = root.path().join(".yconn");
         fs::create_dir_all(&yconn).unwrap();
@@ -749,7 +749,7 @@ mod tests {
         let empty = TempDir::new().unwrap();
         let cfg = load(root.path(), None, empty.path());
 
-        let err = run_setup(&cfg, &no_color(), Some("srv")).unwrap_err();
+        let err = run_install(&cfg, &no_color(), Some("srv")).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("failed to create parent directory"),
@@ -762,7 +762,7 @@ mod tests {
     }
 
     #[test]
-    fn test_run_setup_iterate_all_uncreatable_parent_reports_and_continues() {
+    fn test_run_install_iterate_all_uncreatable_parent_reports_and_continues() {
         let root = TempDir::new().unwrap();
         let yconn = root.path().join(".yconn");
         fs::create_dir_all(&yconn).unwrap();
@@ -788,7 +788,7 @@ mod tests {
 
         // Iterate-all returns Ok; alpha's failure is reported via the
         // renderer's error channel, beta still succeeds.
-        run_setup(&cfg, &no_color(), None).unwrap();
+        run_install(&cfg, &no_color(), None).unwrap();
 
         assert!(
             beta_parent.is_dir(),

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -100,7 +100,11 @@ pub(crate) fn build_key_rows(cfg: &LoadedConfig) -> Vec<KeyRow> {
 /// supplied. The two forms have intentionally different error semantics:
 /// single-name is strict (missing `generate_key` aborts), iterate-all is
 /// lenient (missing `generate_key` is silently skipped).
-pub(crate) fn run_install(cfg: &LoadedConfig, renderer: &Renderer, name: Option<&str>) -> Result<()> {
+pub(crate) fn run_install(
+    cfg: &LoadedConfig,
+    renderer: &Renderer,
+    name: Option<&str>,
+) -> Result<()> {
     match name {
         Some(target) => run_install_named(cfg, renderer, target),
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,8 +92,8 @@ fn main() -> Result<()> {
             let cfg = load_and_warn(&renderer, verbose)?;
             match subcommand {
                 KeyCommands::List => commands::keys::list(&cfg, &renderer),
-                KeyCommands::Setup { name } => {
-                    commands::keys::setup(&cfg, &renderer, name.as_deref())
+                KeyCommands::Install { name } => {
+                    commands::keys::install(&cfg, &renderer, name.as_deref())
                 }
                 KeyCommands::Update { name } => commands::keys::update(
                     &cfg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,14 @@ fn main() -> Result<()> {
             let overrides = parse_user_overrides(&user_overrides)?;
             commands::connect::run(&cfg, &renderer, &name, verbose, &overrides)
         }
-        Commands::Install { layer } => {
+        Commands::Install {
+            layer,
+            connections,
+            keys,
+            ssh_config,
+        } => {
             let cfg = load_and_warn(&renderer, verbose)?;
-            commands::install::run(&cfg, layer)
+            commands::install::run(&cfg, layer, connections, keys, ssh_config)
         }
         Commands::Keys { subcommand } => {
             let cfg = load_and_warn(&renderer, verbose)?;

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2302,12 +2302,12 @@ fn keys_list_filters_to_generate_key_connections() {
     );
 }
 
-/// `yconn keys setup` (no arg) runs `generate_key` for every qualifying
+/// `yconn keys install` (no arg) runs `generate_key` for every qualifying
 /// connection and silently skips connections without `generate_key`.
-/// `yconn keys setup <name>` re-runs generation for a named connection after
+/// `yconn keys install <name>` re-runs generation for a named connection after
 /// the key has been deleted.
 #[test]
-fn keys_setup_all_and_named_create_key_files() {
+fn keys_install_all_and_named_create_key_files() {
     let env = TestEnv::new();
 
     let key_path = env.cwd.path().join("generated_key");
@@ -2340,7 +2340,7 @@ fn keys_setup_all_and_named_create_key_files() {
 
     // Iterate-all form: creates the key file for gen-conn, silently skips
     // pwauth.
-    let out = env.run(&["keys", "setup"]);
+    let out = env.run(&["keys", "install"]);
     TestEnv::assert_ok(&out);
     let contents = fs::read_to_string(&key_path).expect("key file must be created by setup");
     assert_eq!(
@@ -2350,16 +2350,16 @@ fn keys_setup_all_and_named_create_key_files() {
 
     // Delete and re-run via named form to verify the single-connection path.
     fs::remove_file(&key_path).unwrap();
-    let out = env.run(&["keys", "setup", "gen-conn"]);
+    let out = env.run(&["keys", "install", "gen-conn"]);
     TestEnv::assert_ok(&out);
     let contents = fs::read_to_string(&key_path).expect("key file must be recreated");
     assert_eq!(contents, "hello");
 }
 
-/// `yconn keys setup <name>` on a connection with no `generate_key` aborts
+/// `yconn keys install <name>` on a connection with no `generate_key` aborts
 /// non-zero and prints a clear error message.
 #[test]
-fn keys_setup_named_without_generate_key_fails() {
+fn keys_install_named_without_generate_key_fails() {
     let env = TestEnv::new();
 
     env.write_user_config(
@@ -2375,10 +2375,10 @@ fn keys_setup_named_without_generate_key_fails() {
         ),
     );
 
-    let out = env.run(&["keys", "setup", "pwauth"]);
+    let out = env.run(&["keys", "install", "pwauth"]);
     assert!(
         !out.status.success(),
-        "keys setup on no-generate_key connection must exit non-zero"
+        "keys install on no-generate_key connection must exit non-zero"
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
@@ -2387,11 +2387,11 @@ fn keys_setup_named_without_generate_key_fails() {
     );
 }
 
-/// `yconn keys setup <name>` emits a one-line notice containing the connection
+/// `yconn keys install <name>` emits a one-line notice containing the connection
 /// name, source layer label, and absolute source config path immediately before
 /// spawning the generate_key command.
 #[test]
-fn keys_setup_named_emits_layer_path_notice_before_spawn() {
+fn keys_install_named_emits_layer_path_notice_before_spawn() {
     let env = TestEnv::new();
 
     let key_path = env.cwd.path().join("gen_key");
@@ -2411,7 +2411,7 @@ fn keys_setup_named_emits_layer_path_notice_before_spawn() {
     );
     env.write_user_config("connections", &yaml);
 
-    let out = env.run(&["keys", "setup", "bastion"]);
+    let out = env.run(&["keys", "install", "bastion"]);
     TestEnv::assert_ok(&out);
 
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -2435,11 +2435,11 @@ fn keys_setup_named_emits_layer_path_notice_before_spawn() {
     );
 }
 
-/// `yconn keys setup` (iterate-all) emits a one-line notice once per
+/// `yconn keys install` (iterate-all) emits a one-line notice once per
 /// qualifying connection, before each spawn, and does not emit a notice for
 /// connections that are silently skipped (no generate_key).
 #[test]
-fn keys_setup_iterate_all_emits_notice_per_connection() {
+fn keys_install_iterate_all_emits_notice_per_connection() {
     let env = TestEnv::new();
 
     let key_a = env.cwd.path().join("key_a");
@@ -2475,7 +2475,7 @@ fn keys_setup_iterate_all_emits_notice_per_connection() {
     );
     env.write_user_config("connections", &yaml);
 
-    let out = env.run(&["keys", "setup"]);
+    let out = env.run(&["keys", "install"]);
     TestEnv::assert_ok(&out);
 
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -2496,13 +2496,13 @@ fn keys_setup_iterate_all_emits_notice_per_connection() {
     );
 }
 
-/// `yconn keys setup <name>` end-to-end against a key path whose parent does
+/// `yconn keys install <name>` end-to-end against a key path whose parent does
 /// not exist on disk: the parent directory is created before the shell command
 /// runs, the key file is written, and no extra output line appears compared to
 /// the pre-existing-parent case (criterion 5: a pre-existing parent produces
 /// no extra output line).
 #[test]
-fn keys_setup_named_creates_missing_parent_and_emits_no_extra_output() {
+fn keys_install_named_creates_missing_parent_and_emits_no_extra_output() {
     // Run 1: parent does not exist — must be created on demand.
     let env_missing = TestEnv::new();
     let missing_parent = env_missing.cwd.path().join("nested").join("parent");
@@ -2528,7 +2528,7 @@ fn keys_setup_named_creates_missing_parent_and_emits_no_extra_output() {
         "test precondition: parent dir must not exist"
     );
 
-    let out_missing = env_missing.run(&["keys", "setup", "gen-conn"]);
+    let out_missing = env_missing.run(&["keys", "install", "gen-conn"]);
     TestEnv::assert_ok(&out_missing);
 
     assert!(
@@ -2567,7 +2567,7 @@ fn keys_setup_named_creates_missing_parent_and_emits_no_extra_output() {
     );
     env_present.write_user_config("connections", &yaml_present);
 
-    let out_present = env_present.run(&["keys", "setup", "gen-conn"]);
+    let out_present = env_present.run(&["keys", "install", "gen-conn"]);
     TestEnv::assert_ok(&out_present);
 
     let stdout_present = String::from_utf8_lossy(&out_present.stdout);
@@ -2613,10 +2613,10 @@ fn keys_setup_named_creates_missing_parent_and_emits_no_extra_output() {
     );
 }
 
-/// `yconn keys setup <name>` with `generate_key` containing `${user}` must
+/// `yconn keys install <name>` with `generate_key` containing `${user}` must
 /// expand the placeholder to the connection's user value before executing.
 #[test]
-fn keys_setup_expands_user_placeholder_in_generate_key() {
+fn keys_install_expands_user_placeholder_in_generate_key() {
     let env = TestEnv::new();
 
     let key_path = env.cwd.path().join("generated_key");
@@ -2641,8 +2641,8 @@ fn keys_setup_expands_user_placeholder_in_generate_key() {
     // Sanity: file does not exist yet.
     assert!(!key_path.exists(), "key file must not exist before setup");
 
-    // Run keys setup for the connection with ${user} in generate_key.
-    let out = env.run(&["keys", "setup", "user-expansion"]);
+    // Run keys install for the connection with ${user} in generate_key.
+    let out = env.run(&["keys", "install", "user-expansion"]);
     TestEnv::assert_ok(&out);
 
     // The file should be created with content equal to the connection's user value.
@@ -2668,7 +2668,7 @@ fn keys_setup_expands_user_placeholder_in_generate_key() {
 // `${...}` user templates, `users:` map, docker block, group tags, optional
 // fields). It is loaded verbatim into the project layer for steps that need
 // the full feature surface, and a deterministic copy with a rewritten
-// `generate_key` is used for the `keys setup` step.
+// `generate_key` is used for the `keys install` step.
 //
 // The acceptance criteria allow splitting the original golden-path sequence
 // into several independent `#[test]` functions, each starting from fresh
@@ -2977,7 +2977,7 @@ fn test_e2e_ssh_config_install_disable_enable_uninstall() {
     );
 }
 
-// ── Step 14: `yconn keys setup <name>` with a deterministic generate_key ─────
+// ── Step 14: `yconn keys install <name>` with a deterministic generate_key ─────
 //
 // The shipped fixture's `bastion` connection uses a realistic but
 // non-executable command:
@@ -2986,7 +2986,7 @@ fn test_e2e_ssh_config_install_disable_enable_uninstall() {
 // deterministic `echo testkey > ${key}` and the key path points inside the
 // temp HOME so writes are scoped to the test.
 #[test]
-fn test_e2e_keys_setup_runs_generate_key_command() {
+fn test_e2e_keys_install_runs_generate_key_command() {
     let env = TestEnv::new();
     let test_key_path = env.home.path().join("e2e_bastion_key");
     let adapted = format!(
@@ -3014,15 +3014,15 @@ fn test_e2e_keys_setup_runs_generate_key_command() {
     // Sanity: key file must not exist before setup.
     assert!(
         !test_key_path.exists(),
-        "bastion key file must not exist before keys setup"
+        "bastion key file must not exist before keys install"
     );
 
-    let out = env.run(&["keys", "setup", "bastion"]);
+    let out = env.run(&["keys", "install", "bastion"]);
     TestEnv::assert_ok(&out);
 
     assert!(
         test_key_path.exists(),
-        "bastion key file must be created by keys setup"
+        "bastion key file must be created by keys install"
     );
     let key_content = fs::read_to_string(&test_key_path).unwrap();
     assert_eq!(


### PR DESCRIPTION
Closes #121

## Summary

This slice implements the CLI surface and selector-resolution logic for the install command's three phase-selector flags: `--connections`, `--keys`, and `--ssh-config`. The `resolve_selectors()` function applies the default-to-all rule: when no flags are provided, all phases are enabled; when one or more flags are provided, only the flagged phases are enabled.

## Changes per acceptance criterion

**Flag acceptance**: All three flags are accepted as valid boolean arguments in the Install CLI variant.

**Any combination supported**: The CLI variant accepts any combination of the three flags (none, one, two, or all three).

**Default-to-all rule**: The `resolve_selectors(connections: bool, keys: bool, ssh_config: bool) -> InstallSelectors` function returns all three phases enabled when no flags are provided.

**Flagged phases only**: When one or more flags are provided, the function returns only the phases that were explicitly enabled.

**--layer flag retained**: The existing `--layer` flag on the Install variant remains unchanged.

**Unit tests**: Six unit tests cover all combinations:
- No flags → all three phases
- `--connections` only
- `--keys` only
- `--ssh-config` only
- `--connections --keys`
- All three flags

**Note**: Please squash-merge this PR per repo convention.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>