### PR TITLE
Docs update: rename keys setup → keys install and document install selector flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,13 +278,19 @@ When `--verbose` is passed, the full `docker run` command is printed before exec
 | `yconn connections remove <name>` | Remove a connection (prompts for layer if ambiguous) |
 | `yconn connections init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
 | `yconn config` | Show which config files are active, their paths, and Docker status |
+| `yconn install` | Copy project connections into the user (or system) layer |
 | `yconn groups list` | Show all groups found across all layers |
 | `yconn groups use <n>` | Set the active group (persisted to `~/.config/yconn/session.yml`) |
 | `yconn groups clear` | Remove `active_group` from `session.yml`, revert to default (`connections`) |
 | `yconn groups current` | Print the active group name and resolved config file paths |
+| `yconn keys list` | List connections that have a `generate_key` command configured |
+| `yconn keys install [<name>]` | Generate SSH keys by executing `generate_key` for one connection or all qualifying connections |
 
 Global flags:
-- `--layer system|user|project` — target a specific layer for `add`, `edit`, `remove`
+- `--layer system|user|project` — target a specific layer for `add`, `edit`, `remove`, and `install`
+- `--connections` — filter connections by name pattern (repeatable) for `install`
+- `--keys` — filter keys by name for `keys install`
+- `--ssh-config` — include SSH config output in `install`
 - `--all` — include shadowed entries in `yconn connections list`
 - `--no-color` — disable colored output
 - `--verbose` — print config loading decisions, merge resolution, and full Docker invocation

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ yconn connections list
 # Connect
 yconn connect prod-web
 
+# Copy project connections into user layer
+yconn install
+
+# Copy only connections (skip keys and SSH config)
+yconn install --connections
+
 # Switch to a named group
 yconn groups use work
 ```
@@ -80,7 +86,7 @@ yconn groups use work
 | `yconn connections init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
 | `yconn install` | Copy project connections into the user (or system) layer |
 | `yconn keys list` | List connections that have a `generate_key` command configured |
-| `yconn keys setup [<name>]` | Run `generate_key` for one connection or every qualifying connection |
+| `yconn keys install [<name>]` | Run `generate_key` for one connection or every qualifying connection |
 | `yconn config` | Show active config files, their paths, and Docker status |
 | `yconn groups list` | Show all groups found across all layers |
 | `yconn groups use <name>` | Set the active group |
@@ -97,7 +103,9 @@ yconn groups use work
 
 Global flags: `--all`, `--verbose`
 
-Per-subcommand flags: `--layer system|user|project` (for `connections add`, `connections edit`, `connections remove`, `users add`, `users edit`)
+Per-subcommand flags:
+- `--layer system|user|project` — for `connections add`, `connections edit`, `connections remove`, `install`, `users add`, `users edit`
+- `--connections`, `--keys`, `--ssh-config` — selector flags for `install` (install only the selected phase; when none are provided, all phases run)
 
 ## Development
 

--- a/docs/man/yconn.1.md
+++ b/docs/man/yconn.1.md
@@ -92,6 +92,23 @@ keys to be pre-baked into an image rather than distributed to developer machines
 : Show which config files are active, their paths, connection counts, and Docker
   bootstrap status.
 
+**install**
+: Copy project connections into a target layer (user or system). Reads the project
+  `.yconn/connections.yaml` discovered by walking upward from the current directory
+  and copies all connections into the target layer file. For each connection not
+  present in the target file, the entry is appended and a status line is printed.
+  For each connection whose name already exists in the target file, the user is
+  prompted interactively for each one. Non-existent project config causes the
+  command to exit with a clear error. Use **--layer** to target a specific layer
+  (defaults to user; project is not allowed since installing into the project
+  layer is circular). Use selector flags to control which components to install:
+
+  - **--connections** — install the connections: map
+  - **--keys** — install the keys: user entries from the project config
+  - **--ssh-config** — install SSH Host blocks to `~/.ssh/yconn-connections`
+
+  When no selector flags are provided, all three phases are performed.
+
 **group list**
 : Show all unique group values found across connection entries in all loaded
   layers, and which layers contain connections with each group tag.
@@ -116,7 +133,7 @@ keys to be pre-baked into an image rather than distributed to developer machines
   `generate_key` — including all password-auth entries and key/identity
   entries without a `generate_key` field — are omitted from the output.
 
-**keys setup** [*NAME*]
+**keys install** [*NAME*]
 : Generate SSH key material by executing `auth.generate_key` via `sh -c`.
   With no positional argument, every connection with `generate_key`
   configured is processed in turn — connections without `generate_key` are
@@ -124,7 +141,7 @@ keys to be pre-baked into an image rather than distributed to developer machines
   *NAME* is supplied, only that connection is processed: if *NAME* does not
   exist or has no `generate_key` configured, the command aborts non-zero
   without executing anything. When the target key file already exists on
-  disk, setup prints a skip notice and does not execute the command. A
+  disk, install prints a skip notice and does not execute the command. A
   non-zero exit code from the `generate_key` command fails that entry; in
   iterate-all mode subsequent entries are still attempted, in named mode
   the command exits non-zero.

--- a/docs/man/yconn.1.md
+++ b/docs/man/yconn.1.md
@@ -417,8 +417,8 @@ Audit and generate SSH key material:
 
 ```
 yconn keys list
-yconn keys setup               # generate keys for every qualifying connection
-yconn keys setup bastion       # generate the key for a single connection
+yconn keys install               # generate keys for every qualifying connection
+yconn keys install bastion       # generate the key for a single connection
 ```
 
 Manage user key/value entries:


### PR DESCRIPTION
## Summary

Update all user-facing documentation to reflect the renamed `keys install` subcommand (replacing `keys setup`) and document the new `--connections`, `--keys`, `--ssh-config` selector flags on `yconn install`.

## Changes by acceptance criterion

1. **CLAUDE.md CLI table:** Added `yconn install` command with selector flags (`--connections`, `--keys`, `--ssh-config`, `--layer`)

2. **CLAUDE.md CLI table:** Added `yconn keys list` command and renamed `keys setup` to `keys install`

3. **docs/man/yconn.1.md:** Renamed `**keys setup**` to `**keys install**` with updated description

4. **docs/man/yconn.1.md:** Added `**install**` command section documenting `--layer` and selector flags

5. **README.md:** Updated quick-start section with `yconn install` examples showing selector flags; renamed `keys setup` to `keys install`

6. **User-facing documentation:** Verified no remaining references to `keys setup` in `.md` documentation files

## Test plan

- All acceptance criteria verified through documentation review
- Commits are organized per acceptance criterion for clear history

Please squash-merge this PR.

Closes #126

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>