### PR TITLE
Documentation corrections for new install default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ When `--verbose` is passed, the full `docker run` command is printed before exec
 | `yconn connections remove <name>` | Remove a connection (prompts for layer if ambiguous) |
 | `yconn connections init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
 | `yconn config` | Show which config files are active, their paths, and Docker status |
-| `yconn install` | Copy project connections into the user (or system) layer |
+| `yconn install` | Generate keys and write SSH config from project layer (connections skipped unless `--connections` is given) |
 | `yconn groups list` | Show all groups found across all layers |
 | `yconn groups use <n>` | Set the active group (persisted to `~/.config/yconn/session.yml`) |
 | `yconn groups clear` | Remove `active_group` from `session.yml`, revert to default (`connections`) |
@@ -288,9 +288,9 @@ When `--verbose` is passed, the full `docker run` command is printed before exec
 
 Global flags:
 - `--layer system|user|project` — target a specific layer for `add`, `edit`, `remove`, and `install`
-- `--connections` — filter connections by name pattern (repeatable) for `install`
+- `--connections` — enable the connections phase for `install`
 - `--keys` — filter keys by name for `keys install`
-- `--ssh-config` — include SSH config output in `install`
+- `--ssh-config` — enable the ssh-config phase for `install`
 - `--all` — include shadowed entries in `yconn connections list`
 - `--no-color` — disable colored output
 - `--verbose` — print config loading decisions, merge resolution, and full Docker invocation

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ yconn connections list
 # Connect
 yconn connect prod-web
 
-# Copy project connections into user layer
+# Generate keys and SSH config from project layer
 yconn install
 
-# Copy only connections (skip keys and SSH config)
+# Also run the connections phase
 yconn install --connections
 
 # Switch to a named group
@@ -84,7 +84,7 @@ yconn groups use work
 | `yconn connections edit <name>` | Open the connection's source config file in `$EDITOR` |
 | `yconn connections remove <name>` | Remove a connection (prompts for layer if ambiguous) |
 | `yconn connections init` | Scaffold a `<group>.yaml` in `.yconn/` in the current directory |
-| `yconn install` | Copy project connections into the user (or system) layer |
+| `yconn install` | Generate keys and write SSH config from project layer (connections skipped unless `--connections` is given) |
 | `yconn keys list` | List connections that have a `generate_key` command configured |
 | `yconn keys install [<name>]` | Run `generate_key` for one connection or every qualifying connection |
 | `yconn config` | Show active config files, their paths, and Docker status |
@@ -105,7 +105,7 @@ Global flags: `--all`, `--verbose`
 
 Per-subcommand flags:
 - `--layer system|user|project` — for `connections add`, `connections edit`, `connections remove`, `install`, `users add`, `users edit`
-- `--connections`, `--keys`, `--ssh-config` — selector flags for `install` (install only the selected phase; when none are provided, all phases run)
+- `--connections`, `--keys`, `--ssh-config` — selector flags for `install` (when none are provided, keys and ssh-config run)
 
 ## Development
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -138,12 +138,12 @@ pub enum Commands {
         subcommand: GroupCommands,
     },
 
-    /// Copy project connections into a target layer (user or system)
+    /// Generate keys and write SSH config from project layer (connections skipped unless `--connections` is given)
     Install {
         /// Target layer to install connections into (user or system; project is not allowed)
         #[arg(long, value_name = "LAYER")]
         layer: Option<LayerArg>,
-        /// Install connections phase
+        /// Enable the connections phase (off by default)
         #[arg(long)]
         connections: bool,
         /// Install keys phase


### PR DESCRIPTION
## Summary

Update CLI docstrings, README, and CLAUDE.md to reflect the new install default: bare `yconn install` now runs keys and ssh-config only; the connections phase requires an explicit `--connections` flag.

## Changes by acceptance criterion

- **Install variant doc-comment**: Updated to state "Generate keys and write SSH config from project layer (connections skipped unless `--connections` is given)"

- **connections arg docstring**: Updated to describe `--connections` as "Enable the connections phase (off by default)"

- **README Quick-start comments**: Changed "# Copy project connections into user layer" to "# Generate keys and SSH config from project layer" and "# Copy only connections (skip keys and SSH config)" to "# Also run the connections phase"

- **README table description**: Updated `yconn install` entry to describe the new default behavior with `--connections` flag required

- **README selector-flags note**: Updated to state "when none are provided, keys and ssh-config run" instead of "all phases run"

- **CLAUDE.md table row**: Updated `yconn install` description to match new default

- **CLAUDE.md --connections flag**: Changed from "filter connections by name pattern (repeatable) for `install`" to "enable the connections phase for `install`"

- **CLAUDE.md --ssh-config flag**: Changed from "include SSH config output in `install`" to "enable the ssh-config phase for `install`"

## Testing

All existing tests pass. No functional code changes were made — this is purely documentation.

Closes #136

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>