### PR TITLE
Flip install default to skip connections phase

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1089,10 +1089,7 @@ mod tests {
 
         orchestrate_install_phases(&selectors, &mut tracker).unwrap();
 
-        assert_eq!(
-            tracker.ran_phases(),
-            vec!["keys", "ssh_config"]
-        );
+        assert_eq!(tracker.ran_phases(), vec!["keys", "ssh_config"]);
     }
 
     #[test]
@@ -1123,9 +1120,6 @@ mod tests {
         // Even though keys "fails" internally, ssh-config should still run.
         orchestrate_with_keys_failure(&selectors, &mut tracker).unwrap();
 
-        assert_eq!(
-            tracker.ran_phases(),
-            vec!["keys", "ssh_config"]
-        );
+        assert_eq!(tracker.ran_phases(), vec!["keys", "ssh_config"]);
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1083,7 +1083,7 @@ mod tests {
     }
 
     #[test]
-    fn test_orchestrator_no_selectors_runs_all_phases_in_order() {
+    fn test_orchestrator_no_selectors_runs_keys_and_ssh_config() {
         let selectors = resolve_selectors(false, false, false);
         let mut tracker = PhaseTracker::new();
 
@@ -1091,7 +1091,7 @@ mod tests {
 
         assert_eq!(
             tracker.ran_phases(),
-            vec!["connections", "keys", "ssh_config"]
+            vec!["keys", "ssh_config"]
         );
     }
 
@@ -1117,7 +1117,7 @@ mod tests {
             Ok(())
         }
 
-        let selectors = resolve_selectors(false, false, false); // All phases enabled
+        let selectors = resolve_selectors(false, false, false); // Keys and ssh_config enabled
         let mut tracker = PhaseTracker::new();
 
         // Even though keys "fails" internally, ssh-config should still run.
@@ -1125,7 +1125,7 @@ mod tests {
 
         assert_eq!(
             tracker.ran_phases(),
-            vec!["connections", "keys", "ssh_config"]
+            vec!["keys", "ssh_config"]
         );
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -29,16 +29,16 @@ pub struct InstallSelectors {
     pub ssh_config: bool,
 }
 
-/// Resolve selector flags using the default-to-all rule.
+/// Resolve selector flags using the default-to-keys-and-ssh-config rule.
 ///
-/// When none of the flags are provided, all phases are enabled.
+/// When none of the flags are provided, keys and ssh_config phases are enabled.
 /// When one or more flags are provided, only the flagged phases are enabled.
 #[allow(dead_code)]
 pub fn resolve_selectors(connections: bool, keys: bool, ssh_config: bool) -> InstallSelectors {
     if !connections && !keys && !ssh_config {
-        // No flags provided — enable all phases (default-to-all rule).
+        // No flags provided — enable keys and ssh_config phases.
         InstallSelectors {
-            connections: true,
+            connections: false,
             keys: true,
             ssh_config: true,
         }
@@ -923,12 +923,12 @@ mod tests {
     // ── resolve_selectors tests ───────────────────────────────────────────────
 
     #[test]
-    fn test_resolve_selectors_no_flags_enables_all_phases() {
+    fn test_resolve_selectors_no_flags_enables_keys_and_ssh_config() {
         let selectors = resolve_selectors(false, false, false);
         assert_eq!(
             selectors,
             InstallSelectors {
-                connections: true,
+                connections: false,
                 keys: true,
                 ssh_config: true
             }
@@ -994,6 +994,19 @@ mod tests {
             selectors,
             InstallSelectors {
                 connections: true,
+                keys: true,
+                ssh_config: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_selectors_keys_and_ssh_config() {
+        let selectors = resolve_selectors(false, true, true);
+        assert_eq!(
+            selectors,
+            InstallSelectors {
+                connections: false,
                 keys: true,
                 ssh_config: true
             }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2773,7 +2773,10 @@ fn test_e2e_install_system_layer_copies_all_fixture_connections() {
     let env = TestEnv::new();
     env.write_project_config("connections", E2E_FIXTURE);
 
-    let out = env.run_with_stdin(&["install", "--connections", "--layer", "system"], "y\ny\ny\ny\ny\ny\ny\n");
+    let out = env.run_with_stdin(
+        &["install", "--connections", "--layer", "system"],
+        "y\ny\ny\ny\ny\ny\ny\n",
+    );
     TestEnv::assert_ok(&out);
 
     let system_yaml = env.system.path().join("connections.yaml");

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1898,7 +1898,7 @@ fn install_copies_new_connections_to_user_layer() {
         "version: 1\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: deploy\n    auth:\n      type: password\n    description: \"Alpha server\"\n  beta:\n    host: 10.0.0.2\n    user: ops\n    auth:\n      type: password\n    description: \"Beta server\"\n",
     );
 
-    let out = env.run(&["install"]);
+    let out = env.run(&["install", "--connections"]);
     TestEnv::assert_ok(&out);
 
     let user_config = env.xdg_config.path().join("yconn").join("connections.yaml");
@@ -1946,7 +1946,7 @@ fn install_updates_existing_with_y_and_appends_new() {
     );
 
     // Answer `y` to the update prompt for alpha.
-    let out = env.run_with_stdin(&["install"], "y\n");
+    let out = env.run_with_stdin(&["install", "--connections"], "y\n");
     TestEnv::assert_ok(&out);
 
     let user_config = env.xdg_config.path().join("yconn").join("connections.yaml");
@@ -1989,7 +1989,7 @@ fn install_missing_user_variable_prompts_and_writes_value() {
     );
 
     // Provide the value for the missing user variable via stdin.
-    let out = env.run_with_stdin(&["install"], "alice\n");
+    let out = env.run_with_stdin(&["install", "--connections"], "alice\n");
     TestEnv::assert_ok(&out);
 
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -2069,7 +2069,7 @@ fn install_project_users_block_resolves_variable_without_prompt() {
         "version: 1\n\nusers:\n  t1user: alice\n\nconnections:\n  alpha:\n    host: 10.0.0.1\n    user: \"${t1user}\"\n    auth:\n      type: password\n    description: \"Alpha server\"\n",
     );
 
-    let out = env.run(&["install"]);
+    let out = env.run(&["install", "--connections"]);
     TestEnv::assert_ok(&out);
 
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -2745,7 +2745,7 @@ fn test_e2e_install_user_layer_copies_all_fixture_connections() {
     let env = TestEnv::new();
     env.write_project_config("connections", E2E_FIXTURE);
 
-    let out = env.run(&["install", "--layer", "user"]);
+    let out = env.run(&["install", "--connections", "--layer", "user"]);
     TestEnv::assert_ok(&out);
 
     let user_yaml = env.xdg_config.path().join("yconn").join("connections.yaml");
@@ -2773,7 +2773,7 @@ fn test_e2e_install_system_layer_copies_all_fixture_connections() {
     let env = TestEnv::new();
     env.write_project_config("connections", E2E_FIXTURE);
 
-    let out = env.run_with_stdin(&["install", "--layer", "system"], "y\ny\ny\ny\ny\ny\ny\n");
+    let out = env.run_with_stdin(&["install", "--connections", "--layer", "system"], "y\ny\ny\ny\ny\ny\ny\n");
     TestEnv::assert_ok(&out);
 
     let system_yaml = env.system.path().join("connections.yaml");

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -3673,11 +3673,11 @@ fn test_install_no_selectors_runs_all_phases() {
     let out = env.run(&["install"]);
     TestEnv::assert_ok(&out);
 
-    // Verify connections phase ran: user-layer config should exist.
+    // Verify connections phase did NOT run: user-layer config should NOT exist.
     let user_config = env.xdg_config.path().join("yconn").join("connections.yaml");
     assert!(
-        user_config.exists(),
-        "connections phase must create user-layer config"
+        !user_config.exists(),
+        "connections phase must NOT run with no flags"
     );
 
     // Verify keys phase ran: key file should exist.


### PR DESCRIPTION
## Summary

Flips the no-flags default of `resolve_selectors()` so bare `yconn install` runs only keys and ssh-config phases and skips the connections phase.

## Changes per acceptance criterion

1. **Default selector behavior**: `resolve_selectors(false, false, false)` now returns `connections: false, keys: true, ssh_config: true` instead of all three true.

2. **Explicit connections flag**: `resolve_selectors(true, false, false)` maintains the behavior of returning `connections: true, keys: false, ssh_config: false`.

3. **Explicit keys and ssh_config**: `resolve_selectors(false, true, true)` correctly returns `connections: false, keys: true, ssh_config: true`.

4. **All three flags**: `resolve_selectors(true, true, true)` maintains the behavior of returning all three true.

5. **Updated doc-comment**: The function's doc-comment now describes the new default-to-keys-and-ssh-config rule instead of default-to-all.

6. **Updated test for no-flags default**: `test_resolve_selectors_no_flags_enables_all_phases` renamed to `test_resolve_selectors_no_flags_enables_keys_and_ssh_config` and updated to assert the new behavior.

7. **Updated orchestrator test**: `test_orchestrator_no_selectors_runs_all_phases_in_order` renamed to `test_orchestrator_no_selectors_runs_keys_and_ssh_config` and updated to assert `vec![\"keys\", \"ssh_config\"]`.

8. **Updated keys failure test**: `test_orchestrator_keys_failure_does_not_abort_ssh_config` updated to assert `vec![\"keys\", \"ssh_config\"]` instead of all three phases.

9. **New test for coverage**: Added `test_resolve_selectors_keys_and_ssh_config` to test the `(false, true, true)` case explicitly.

10. **All tests pass**: Updated functional tests to pass `--connections` flag when they need to install connections. All 495 unit and integration tests pass.

Closes #135

Please squash-merge this PR.